### PR TITLE
bug(api): allow app to start without i2c presence for sensors

### DIFF
--- a/app/sensors/humidity/humidity.py
+++ b/app/sensors/humidity/humidity.py
@@ -54,9 +54,13 @@ class HumiditySensor(CachedSensor):
         """
         return self._sensor.relative_humidity
 
-i2c = board.I2C()
-base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
-humidity_sensor = HumiditySensor(base_sensor)
+humidity_sensor = None
+try:
+    i2c = board.I2C()
+    base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
+    humidity_sensor = HumiditySensor(base_sensor)
+except:
+    print("Failed to initiate humidity sensor")
 
 if __name__ == "__main__":
     """

--- a/app/sensors/temperature/temperature.py
+++ b/app/sensors/temperature/temperature.py
@@ -58,9 +58,14 @@ class TemperatureSensor(CachedSensor):
         """
         return self._sensor.temperature
 
-i2c = board.I2C()
-base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
-temp_sensor = TemperatureSensor(base_sensor)
+temp_sensor = None 
+
+try:
+    i2c = board.I2C()
+    tbase_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
+    temp_sensor = TemperatureSensor(base_sensor)
+except:
+    print("Failed to initiate temperature sensor")
 
 if __name__ == "__main__":
     """


### PR DESCRIPTION
```
ValueError: No Hardware I2C on (scl,sda)=(3, 2)
Valid I2C ports: ((1, 3, 2), (0, 1, 0))
```