### PR TITLE
allow cors

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
 from app import create_app
+from flask_cors import CORS
 
 app = create_app('default')
+CORS(app)
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
calling API from an app would fail due to CORS, allowing it to integrate with the API from the Flutter app in https://github.com/ammaratef45/hydroponics-garden/issues/21

for this change to work you need to run `pip install flask-cors`, you can integrate that in the docker image