### PR TITLE
feat!: changed pumps domain from light to fan

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -71,16 +71,16 @@ def send_discovery_messages(client):
     client.publish(TEMP_CONFIG_TOPIC, json.dumps(temp_config_payload), retain=True)
 
     #Config for Pump (as a switch with speed control, for example)
-    TEMP_CONFIG_TOPIC = "homeassistant/light/gardyn/"+IDENTIFIER+"_pump/config"
+    TEMP_CONFIG_TOPIC = "homeassistant/pump/gardyn/"+IDENTIFIER+"_pump/config"
     temp_config_payload = {
         "name": "Pump",
         "unique_id": IDENTIFIER + "_pump",
         "platform": "mqtt",
         "state_topic": BASE_TOPIC + "/pump/state",
         "command_topic": BASE_TOPIC + "/pump/command",
-        "brightness_state_topic": BASE_TOPIC + "/pump/speed/state",
-        "brightness_command_topic": BASE_TOPIC + "/pump/speed/set",
-        "brightness_scale": 100,
+        "percentage_state_topic": BASE_TOPIC + "/pump/speed/state",
+        "percentage_command_topic": BASE_TOPIC + "/pump/speed/set",
+        "speed_range_max": 100,
         "device": device_info
     }
     client.publish(TEMP_CONFIG_TOPIC, json.dumps(temp_config_payload), retain=True)


### PR DESCRIPTION
Avoiding having 2 gardyn "lights" for home assistant auto discovery, for easier distinction; pump feels more simliar to a fan than a light to me (spinny things)

BREAKING CHANGE: in home assistant: necessary to change domains for entities and services (in lovelace cards, automations, scripts, ..) from light. to fan. 