### PR TITLE
feat: limit user input

### DIFF
--- a/automations/lights.yml
+++ b/automations/lights.yml
@@ -17,7 +17,7 @@ trigger:
     at: "20:00:00"
     id: "off"
 action:
-  - service: light.turn_{{ 'on' if trigger.id == 'on' else 'off' }}
+  - service: light.turn_{{trigger.id}}
     target:
       entity_id: light.gardyn_light
     data: >

--- a/automations/lights.yml
+++ b/automations/lights.yml
@@ -2,34 +2,28 @@ description: Schedule for Gardyn light control
 trigger:
   - platform: time
     at: "06:00:00"
+    id: "on"
+    variables:
+      brightness_pct: 70
   - platform: time
     at: "09:00:00"
+    id: "off"
   - platform: time
     at: "17:00:00"
+    id: "on"
+    variables:
+      brightness_pct: 50
   - platform: time
     at: "20:00:00"
+    id: "off"
 action:
-  - choose:
-      - conditions:
-          - condition: template
-            value_template: "{{ trigger.now.strftime('%H:%M:%S') in ['06:00:00', '17:00:00'] }}"
-        sequence:
-          - service: light.turn_on
-            entity_id: light.gardyn_light
-            data:
-              brightness_pct: 50
-      - conditions:
-          - condition: template
-            value_template: "{{ trigger.now.strftime('%H:%M:%S') == '09:00:00' }}"
-        sequence:
-          - service: light.turn_on
-            entity_id: light.gardyn_light
-            data:
-              brightness_pct: 70
-      - conditions:
-          - condition: template
-            value_template: "{{ trigger.now.strftime('%H:%M:%S') == '20:00:00' }}"
-        sequence:
-          - service: light.turn_off
-            entity_id: light.gardyn_light
+  - service: light.turn_{{ 'on' if trigger.id == 'on' else 'off' }}
+    target:
+      entity_id: light.gardyn_light
+    data: >
+      {% if trigger.id == "on" %}
+        {"brightness_pct": {{brightness_pct}} }
+      {% else %}
+        {}
+      {% endif %}
 mode: single


### PR DESCRIPTION
# <refactor>(home assistant automations): limit user input to trigger part

## Description

avoid having to change the time in both trigger and conditions, just to change schedule / not break functionality

## Type of change

## How Has This Been Tested?

- [x] automations ran successfully in my home assistant home assistant

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
