### PR TITLE
fix(home assistant): HA autom. entity domain 

### DIFF
--- a/automations/pump.yml
+++ b/automations/pump.yml
@@ -3,32 +3,24 @@ description: Schedule for Gardyn pump control
 trigger:
   - platform: time
     at: "09:30:00"
+    id: "on"
   - platform: time
     at: "09:35:00"
+    id: "off"
   - platform: time
     at: "16:00:00"
+    id: "on"
   - platform: time
     at: "16:05:00"
+    id: "off"
   - platform: time
     at: "21:00:00"
+    id: "on"
   - platform: time
     at: "21:05:00"
+    id: "off"
 action:
-  - choose:
-      - conditions:
-          - condition: template
-            value_template: >-
-              {{ trigger.now.strftime('%H:%M:%S') in ['09:30:00', '16:00:00',
-              '21:00:00'] }}
-        sequence:
-          - service: light.turn_on
-            entity_id: light.gardyn_pump
-      - conditions:
-          - condition: template
-            value_template: >-
-              {{ trigger.now.strftime('%H:%M:%S') in ['09:35:00', '16:05:00',
-              '21:05:00'] }}
-        sequence:
-          - service: light.turn_off
-            entity_id: light.gardyn_pump
-mode: single
+  - service: fan.turn_{{trigger.id}}
+    target:
+      entity_id: fan.gardyn_pump
+mode: queued


### PR DESCRIPTION
# home assistant pump automation: change entity domain from light to fan and limit user input to trigger part

## Description

1. changed entity domain for the pump from light to fan in the home assistant automation, as the pump is mqtt auto detected as a pump now with #52 

2. same as #71 , just for the pump instead of lights
(avoid having to change the times in both trigger and conditions, just to change schedule / not break functionality)

## Type of change

## How Has This Been Tested?

- [x] automations ran successfully in my home assistant home assistant

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
