### PR TITLE
feat: Add light and water commands

### DIFF
--- a/bin/light.sh
+++ b/bin/light.sh
@@ -3,10 +3,11 @@
 # light <brightness|on|off>
 # on = brightness 70
 
-brightness_min=1
-brightness_max=15
+# 70 is Gardyn's "100%"
+brightness_default=70
 
-brightness=70
+brightness_min=1
+brightness_max=100
 
 NC=$(echo -e '\033[0m') ;
 IT=$(echo -e '\033[3m') ;
@@ -32,7 +33,7 @@ EOF
 if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
 	brightness=${1} ;
 elif [[ "${1}" == "on" ]] ; then
-	brightness=70 ;
+	brightness=${brightness_default} ;
 elif [[ "${1}" == "off" ]] ; then
 	light_off ;
 	exit 0 ;

--- a/bin/light.sh
+++ b/bin/light.sh
@@ -1,70 +1,94 @@
 #!/usr/bin/env bash
 
-# light <brightness|on|off>
-# on = brightness 70
+# Script to control Gardyn lights
+# Usage: light <brightness|on|off>
+# "on" sets brightness to 70%, valid brightness range is 4%-100%
 
+# -e exit immediately 
+# -u undefined variables trigger error
+# -o exit with first piped failure
 set -euo pipefail
 
-# If invalid brightness is specified, should we set
-# gardyn lights to brightness_default (70%)?
-light_by_default=true
+# Constants
+readonly BRIGHTNESS_DEFAULT=70
+readonly BRIGHTNESS_MIN=0
+readonly BRIGHTNESS_MAX=100
+readonly LIGHT_BY_DEFAULT=true   # Whether to default to 70% brightness on invalid input
 
-# 70 is Gardyn's "100%"
-brightness_default=70
+RST=$(echo -e '\e[0m')
+ITL=$(echo -e '\e[3m')
 
-# minimum 4%, maximum 100%; lower than 4% just flashes
-brightness_min=4
-brightness_max=100
+# Get Garden of Eden path from script location
+GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..")
 
-RST=$(echo -e '\e[0m') ;
-ITL=$(echo -e '\e[3m') ;
-
-# get Garden of Eden path from script location
-GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..") ;
-
-
-light_off() {
-	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --off ;
+# Turn off the light
+turn_off_light() {
+    "${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --off
 }
 
-light_on() {
-	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --on --brightness "${1}" ;
+# Turn on the light with specified brightness
+turn_on_light() {
+    local brightness="$1"
+    "${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --on --brightness "${brightness}"
 }
 
+# Print usage information
 usage() {
-	cat << EOF
-  light <off|on|${ITL}brightness${RST}>
-  brightness value must be ${brightness_min}–${brightness_max}; "on" defaults to ${brightness_default}.
-  Example: light 65
+    cat << EOF
+Usage: light <off|on|${ITL}brightness${RST}>
+Brightness value must be ${BRIGHTNESS_MIN}-${BRIGHTNESS_MAX}; "on" defaults to ${BRIGHTNESS_DEFAULT}.
+Example: light 65
 EOF
 }
 
-# Max-accepted valid input is "100"
-if [[ ${#1} -gt 3 ]] ; then
-	echo 'ERROR: Input too many characters' ;
-  usage ;
-	exit 1 ;
-elif [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
-	brightness=${1} ;
-elif [[ "${1}" == "on" ]] ; then
-	brightness=${brightness_default} ;
-elif [[ "${1}" == "off" ]] ; then
-	light_off ;
-	exit 0 ;
-else
-	echo 'ERROR: Unrecognized input format' ;
-	usage ;
-	exit 1 ;
-fi
+# Validate brightness
+validate_brightness() {
+    local brightness="$1"
+    if [[ "${brightness}" -ge "${BRIGHTNESS_MIN}" && "${brightness}" -le "${BRIGHTNESS_MAX}" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
-if [[ (( ${brightness} -ge ${brightness_min} )) && (( ${brightness} -le ${brightness_max} )) ]] ; then
-	light_on "${brightness}" ;
-elif [[ ${light_by_default} ]] ; then
-	light_on "${brightness_default}" ;
-else
-	echo "ERROR: Input must be between ${brightness_min}–${brightness_max}" ;
-	usage ;
-	exit 1 ;
-fi
+# Main logic
+main() {
+    if [[ $# -eq 0 ]]; then
+        echo "ERROR: No arguments provided"
+        usage
+        exit 1
+    fi
 
-exit 0 ;
+    local brightness
+
+    case "$1" in
+        off)
+            turn_off_light
+            exit 0
+            ;;
+        on)
+            brightness="${BRIGHTNESS_DEFAULT}"
+            ;;
+        ''|*[!0-9]*)
+            echo "ERROR: Unrecognized input format"
+            usage
+            exit 1
+            ;;
+        *)
+            brightness="$1"
+            ;;
+    esac
+
+    if validate_brightness "${brightness}"; then
+        turn_on_light "${brightness}"
+    elif [[ "${LIGHT_BY_DEFAULT}" == true ]]; then
+        turn_on_light "${BRIGHTNESS_DEFAULT}"
+    else
+        echo "ERROR: Brightness must be between ${BRIGHTNESS_MIN}-${BRIGHTNESS_MAX}"
+        usage
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"

--- a/bin/light.sh
+++ b/bin/light.sh
@@ -3,30 +3,39 @@
 # light <brightness|on|off>
 # on = brightness 70
 
+set -euo pipefail
+
+# If invalid brightness is specified, should we set
+# gardyn lights to brightness_default (70%)?
+light_by_default=true
+
 # 70 is Gardyn's "100%"
 brightness_default=70
 
-brightness_min=1
+# minimum 4%, maximum 100%; lower than 4% just flashes
+brightness_min=4
 brightness_max=100
 
-NC=$(echo -e '\033[0m') ;
-IT=$(echo -e '\033[3m') ;
+RST=$(echo -e '\e[0m') ;
+ITL=$(echo -e '\e[3m') ;
+
+# get Garden of Eden path from script location
+GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..") ;
+
 
 light_off() {
-	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/light/light.py" --off ;
+	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --off ;
 }
 
 light_on() {
-	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/light/light.py" --on --brightness "${1}" ;
+	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/light/light.py" --on --brightness "${1}" ;
 }
 
 usage() {
 	cat << EOF
-  light <off|on|${IT}brightness${NC}>
-  brightness value must be 1–100; "on" defaults to 70.
-
-  e.g.:
-    light 65
+  light <off|on|${ITL}brightness${RST}>
+  brightness value must be ${brightness_min}–${brightness_max}; "on" defaults to ${brightness_default}.
+  Example: light 65
 EOF
 }
 
@@ -44,6 +53,8 @@ fi
 
 if [[ (( ${brightness} -ge ${brightness_min} )) && (( ${brightness} -le ${brightness_max} )) ]] ; then
 	light_on "${brightness}" ;
+elif [[ ${light_by_default} ]] ; then
+	light_on "${brightness_default}" ;
 else
 	usage ;
 	exit 2 ;

--- a/bin/light.sh
+++ b/bin/light.sh
@@ -39,7 +39,12 @@ usage() {
 EOF
 }
 
-if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
+# Max-accepted valid input is "100"
+if [[ ${#1} -gt 3 ]] ; then
+	echo 'ERROR: Input too many characters' ;
+  usage ;
+	exit 1 ;
+elif [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
 	brightness=${1} ;
 elif [[ "${1}" == "on" ]] ; then
 	brightness=${brightness_default} ;
@@ -47,6 +52,7 @@ elif [[ "${1}" == "off" ]] ; then
 	light_off ;
 	exit 0 ;
 else
+	echo 'ERROR: Unrecognized input format' ;
 	usage ;
 	exit 1 ;
 fi
@@ -56,8 +62,9 @@ if [[ (( ${brightness} -ge ${brightness_min} )) && (( ${brightness} -le ${bright
 elif [[ ${light_by_default} ]] ; then
 	light_on "${brightness_default}" ;
 else
+	echo "ERROR: Input must be between ${brightness_min}–${brightness_max}" ;
 	usage ;
-	exit 2 ;
+	exit 1 ;
 fi
 
 exit 0 ;

--- a/bin/light.sh
+++ b/bin/light.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# light <brightness|on|off>
+# on = brightness 70
+
+brightness_min=1
+brightness_max=15
+
+brightness=70
+
+NC=$(echo -e '\033[0m') ;
+IT=$(echo -e '\033[3m') ;
+
+light_off() {
+	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/light/light.py" --off ;
+}
+
+light_on() {
+	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/light/light.py" --on --brightness "${1}" ;
+}
+
+usage() {
+	cat << EOF
+  light <off|on|${IT}brightness${NC}>
+  brightness value must be 1–100; "on" defaults to 70.
+
+  e.g.:
+    light 65
+EOF
+}
+
+if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
+	brightness=${1} ;
+elif [[ "${1}" == "on" ]] ; then
+	brightness=70 ;
+elif [[ "${1}" == "off" ]] ; then
+	light_off ;
+	exit 0 ;
+else
+	usage ;
+	exit 1 ;
+fi
+
+if [[ (( ${brightness} -ge ${brightness_min} )) && (( ${brightness} -le ${brightness_max} )) ]] ; then
+	light_on "${brightness}" ;
+else
+	usage ;
+	exit 2 ;
+fi
+
+exit 0 ;

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -219,6 +219,14 @@ function check_i2c_sensors {
     check_device "AM2320" "5c" "10" "0.002"
 }
 
+create_bash_script_symlinks() {
+    if [[ ! -d "${HOME}/bin/" ]] ; then
+        mkdir "${HOME}/bin/" ;
+    fi
+    ln -fs "${HOME}/garden-of-eden/bin/light.sh" "${HOME}/bin/light"
+    ln -fs "${HOME}/garden-of-eden/bin/water.sh" "${HOME}/bin/water"
+}
+
 # Ensure pigpio daemon runs after system reboots
 function enable_pigpiod_service {
     sudo systemctl enable pigpiod
@@ -266,6 +274,8 @@ ensure_env_file
 add_user_to_groups
 check_i2c_sensors
 add_sensor_type_to_env
+
+create_bash_script_symlinks
 
 #Note: pigpiod will be started by mqtt.service
 #enable_pigpiod_service

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -219,12 +219,9 @@ function check_i2c_sensors {
     check_device "AM2320" "5c" "10" "0.002"
 }
 
-create_bash_script_symlinks() {
-    if [[ ! -d "${HOME}/.local/bin/" ]] ; then
-        mkdir "${HOME}/.local/bin/" ;
-    fi
-    ln -fs "${INSTALL_DIR}/bin/light.sh" "${HOME}/.local/bin/light"
-    ln -fs "${INSTALL_DIR}/bin/water.sh" "${HOME}/.local/bin/water"
+function create_bash_script_symlinks() {
+    ln -fs "${INSTALL_DIR}/bin/light.sh" "/usr/local/bin/light"
+    ln -fs "${INSTALL_DIR}/bin/water.sh" "/usr/local/bin/water"
 }
 
 # Ensure pigpio daemon runs after system reboots

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -220,11 +220,11 @@ function check_i2c_sensors {
 }
 
 create_bash_script_symlinks() {
-    if [[ ! -d "${HOME}/bin/" ]] ; then
-        mkdir "${HOME}/bin/" ;
+    if [[ ! -d "${HOME}/.local/bin/" ]] ; then
+        mkdir "${HOME}/.local/bin/" ;
     fi
-    ln -fs "${HOME}/garden-of-eden/bin/light.sh" "${HOME}/bin/light"
-    ln -fs "${HOME}/garden-of-eden/bin/water.sh" "${HOME}/bin/water"
+    ln -fs "${INSTALL_DIR}/bin/light.sh" "${HOME}/.local/bin/light"
+    ln -fs "${INSTALL_DIR}/bin/water.sh" "${HOME}/.local/bin/water"
 }
 
 # Ensure pigpio daemon runs after system reboots

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# water <minutes|on|off>
+# on = 5 minutes
+
+minutes_min=1
+minutes_max=15
+
+minutes=5
+
+NC=$(echo -e '\033[0m') ;
+IT=$(echo -e '\033[3m') ;
+
+water_off() {
+	 "${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --off ;
+}
+
+water_on() {
+	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --on --speed 100 ;
+	sleep $((${1} * 60)) ;
+	water_off ;
+}
+
+usage() {
+	cat << EOF
+  water <off|on|${IT}minutes${NC}>
+  minutes value must be 1–15; "on" defaults to 5.
+
+  e.g.:
+    water 2
+EOF
+}
+
+if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
+	minutes="${1}" ;
+elif [[ "${1}" == "on" ]] ; then
+	minutes=5 ;
+elif [[ "${1}" == "off" ]] ; then
+	water_off ;
+	exit 0 ;
+else
+	usage ;
+	exit 1 ;
+fi
+
+if [[ (( ${minutes} -ge ${minutes_min} )) && (( ${minutes} -le ${minutes_max} )) ]] ; then
+	water_on "${minutes}" ;
+else
+	usage ;
+	exit 2 ;
+fi
+
+exit 0 ;

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -3,53 +3,134 @@
 # water <minutes|on|off>
 # on = 5 minutes
 
-minutes_default=5
+set -euo pipefail
 
-minutes_min=1
-minutes_max=15
+# If invalid time is specified, should we set
+# gardyn to pump water for time_default (5 min)?
+water_by_default=true
 
+# 5 minutes is Gardyn's default watering time
+time_default=5m
+
+# minimum 1 second, maximum 15 minutes
+time_min=1s
+time_max=15m
+
+# 100 speed is used in README; change if necessary
 speed=100
 
+# We have not yet started water this session
+water_state=0
+
+# bytes for plain / italic
 NC=$(echo -e '\033[0m') ;
 IT=$(echo -e '\033[3m') ;
 
-water_off() {
-	 "${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --off ;
-}
+# get Garden of Eden path from env
+if [[ ! -d ${GOE_PATH:-} ]] ; then
+	wild_guess=$(realpath "$(find /home/ -type d -name garden-of-eden)") ;
+	if [[ -z "${wild_guess}" ]] ; then
+		wild_guess='/path/to/garden-of-eden' ;
+	fi
+	cat << EOF
+ERROR: The garden-of-eden environment path is incorrect or not set
+       Try addding something to your .profile like:
 
-water_on() {
-	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --on --speed ${speed} ;
-	sleep $((${1} * 60)) ;
-	water_off ;
+GOE_PATH="${wild_guess}" ;
+export GOE_PATH ;
+EOF
+	exit 1 ;
+fi
+
+# e.g. 3m => 180; 1m45s => 105
+time_to_seconds() {
+	echo $(($(sed 's/m/*60\+/g; s/s//g; s/+[ ]*$//g' <<< "${1}"))) ;
 }
 
 usage() {
 	cat << EOF
-  water <off|on|${IT}minutes${NC}>
-  minutes value must be 1–15; "on" defaults to 5.
-
-  e.g.:
-    water 2
+  water <off|on|${IT}xmys${NC}>
+  Valid values ${time_min}–${time_max}; "on" defaults to ${time_default}.
+  Example: water 1m15s
 EOF
 }
 
-if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
-	minutes="${1}" ;
+water_off() {
+	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --off ;
+	water_state=0 ;
+}
+
+water_on() {
+	water_state=1 ;
+	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --on --speed ${speed} ;
+}
+
+water_for_time() {
+	water_on ;
+	sleep "${1}" ;
+	water_off ;
+}
+
+# Function to double-check water is off on most exit conditions
+water_exit() {
+  if [[ ${water_state} -gt 0 ]] ; then
+		water_off ;
+	fi
+}
+
+# Function to turn off water on most error / termination conditions
+water_kill() {
+	error_code=$? ;
+	echo "Warning: Received termination signal! Stopping water..." ;
+	water_off ;
+	echo "Water stopped, exiting" ;
+	exit "${error_code}" ;
+}
+
+# Catch common error / interrupt signals and turn off the water
+## Note: SIGKILL / SIGSTOP cannot be trapped
+trap water_kill SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
+# Double-check water is off on any normal exit
+trap water_exit EXIT
+
+# Max-accepted valid input is "13m120s"
+if [[ ${#1} -gt 7 ]] ; then
+	echo 'ERROR: Input too long!' ;
+  usage ;
+	exit 1 ;
+# No suffix specified; assume minutes <= 15, seconds otherwise
+elif [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
+	if [[ (( ${1} -le 15 )) ]] ; then
+		time="${1}m" ;
+	else
+		time="${1}s" ;
+	fi
+# time is in xmys format
+elif [[ "${1}" =~ ^([0-9]{1,3}[ms]{1})([0-9]{1,3}s)?$ ]] ; then
+	time="${1}" ;
 elif [[ "${1}" == "on" ]] ; then
-	minutes=${minutes_default} ;
+	time=${time_default} ;
 elif [[ "${1}" == "off" ]] ; then
 	water_off ;
 	exit 0 ;
 else
+	echo 'ERROR: Unrecognized input format!' ;
 	usage ;
 	exit 1 ;
 fi
 
-if [[ (( ${minutes} -ge ${minutes_min} )) && (( ${minutes} -le ${minutes_max} )) ]] ; then
-	water_on "${minutes}" ;
+seconds=$(time_to_seconds "${time}") ;
+seconds_min=$(time_to_seconds "${time_min}") ;
+seconds_max=$(time_to_seconds "${time_max}") ;
+
+if [[ (( ${seconds} -ge ${seconds_min} )) && (( ${seconds} -le ${seconds_max} )) ]] ; then
+	water_for_time "${seconds}" ;
+elif [[ ${water_by_default} ]] ; then
+	water_for_time "${time_default}" ;
 else
+	echo 'ERROR: Unrecognized input format!' ;
 	usage ;
-	exit 2 ;
+	exit 1 ;
 fi
 
 exit 0 ;

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -52,6 +52,7 @@ water_on() {
 	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --on --speed ${speed} ;
 }
 
+# Function turns on water, sleeps for input time, turns water off
 water_for_time() {
 	water_on ;
 	sleep "${1}" ;
@@ -82,7 +83,7 @@ trap water_exit EXIT
 
 # Max-accepted valid input is "13m120s"
 if [[ ${#1} -gt 7 ]] ; then
-	echo 'ERROR: Input too long!' ;
+	echo 'ERROR: Input too many characters' ;
   usage ;
 	exit 1 ;
 # No suffix specified; assume minutes <= 15, seconds otherwise
@@ -101,7 +102,7 @@ elif [[ "${1}" == "off" ]] ; then
 	water_off ;
 	exit 0 ;
 else
-	echo 'ERROR: Unrecognized input format!' ;
+	echo 'ERROR: Unrecognized input format' ;
 	usage ;
 	exit 1 ;
 fi
@@ -115,7 +116,7 @@ if [[ (( ${seconds} -ge ${seconds_min} )) && (( ${seconds} -le ${seconds_max} ))
 elif [[ ${water_by_default} ]] ; then
 	water_for_time "${time_default}" ;
 else
-	echo 'ERROR: Unrecognized input format!' ;
+	echo "ERROR: Input must be between ${time_min}–${time_max}" ;
 	usage ;
 	exit 1 ;
 fi

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -3,10 +3,12 @@
 # water <minutes|on|off>
 # on = 5 minutes
 
+minutes_default=5
+
 minutes_min=1
 minutes_max=15
 
-minutes=5
+speed=100
 
 NC=$(echo -e '\033[0m') ;
 IT=$(echo -e '\033[3m') ;
@@ -16,7 +18,7 @@ water_off() {
 }
 
 water_on() {
-	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --on --speed 100 ;
+	"${HOME}/garden-of-eden/venv/bin/python" "${HOME}/garden-of-eden/app/sensors/pump/pump.py" --on --speed ${speed} ;
 	sleep $((${1} * 60)) ;
 	water_off ;
 }
@@ -34,7 +36,7 @@ EOF
 if [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
 	minutes="${1}" ;
 elif [[ "${1}" == "on" ]] ; then
-	minutes=5 ;
+	minutes=${minutes_default} ;
 elif [[ "${1}" == "off" ]] ; then
 	water_off ;
 	exit 0 ;

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -26,21 +26,8 @@ water_state=0
 NC=$(echo -e '\033[0m') ;
 IT=$(echo -e '\033[3m') ;
 
-# get Garden of Eden path from env
-if [[ ! -d ${GOE_PATH:-} ]] ; then
-	wild_guess=$(realpath "$(find /home/ -type d -name garden-of-eden)") ;
-	if [[ -z "${wild_guess}" ]] ; then
-		wild_guess='/path/to/garden-of-eden' ;
-	fi
-	cat << EOF
-ERROR: The garden-of-eden environment path is incorrect or not set
-       Try addding something to your .profile like:
-
-GOE_PATH="${wild_guess}" ;
-export GOE_PATH ;
-EOF
-	exit 1 ;
-fi
+# get Garden of Eden path from script location
+GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..") ;
 
 # e.g. 3m => 180; 1m45s => 105
 time_to_seconds() {

--- a/bin/water.sh
+++ b/bin/water.sh
@@ -1,124 +1,102 @@
 #!/usr/bin/env bash
 
-# water <minutes|on|off>
-# on = 5 minutes
+# Script to control Gardyn water pump
+# Usage: water <seconds|on|off>
+# "on" defaults to 300 seconds (5 minutes), valid time range is 1 to 900 seconds (15 minutes).
 
+# -e exit immediately
+# -u undefined variables trigger error
+# -o exit with first piped failure
 set -euo pipefail
 
-# If invalid time is specified, should we set
-# gardyn to pump water for time_default (5 min)?
-water_by_default=true
+# Constants
+readonly TIME_DEFAULT=300    # 5 minutes in seconds
+readonly TIME_MIN=1          # 1 second
+readonly TIME_MAX=900        # 15 minutes in seconds
+readonly SPEED=50
+readonly WATER_BY_DEFAULT=true  # Whether to default to TIME_DEFAULT on invalid input
 
-# 5 minutes is Gardyn's default watering time
-time_default=5m
+NC=$(echo -e '\033[0m')
+IT=$(echo -e '\033[3m')
 
-# minimum 1 second, maximum 15 minutes
-time_min=1s
-time_max=15m
+# Get Garden of Eden path from script location
+GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..")
 
-# 100 speed is used in README; change if necessary
-speed=100
-
-# We have not yet started water this session
-water_state=0
-
-# bytes for plain / italic
-NC=$(echo -e '\033[0m') ;
-IT=$(echo -e '\033[3m') ;
-
-# get Garden of Eden path from script location
-GOE_PATH=$(realpath "$(dirname "$(readlink -e "${0}")")/..") ;
-
-# e.g. 3m => 180; 1m45s => 105
-time_to_seconds() {
-	echo $(($(sed 's/m/*60\+/g; s/s//g; s/+[ ]*$//g' <<< "${1}"))) ;
+# Turn off water pump
+turn_off_water() {
+    "${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --off
 }
 
+# Turn on water pump
+turn_on_water() {
+    "${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --on --speed "${SPEED}"
+}
+
+# Function to water for a specified time, then turn off
+water_for_time() {
+    local time="$1"
+	echo "Watering for ${time} seconds."
+    turn_on_water
+    sleep "${time}"
+    # turn_off_water # turn off will be caught by the exit trap.
+}
+
+# Function to handle exit signals, ensuring the water pump is turned off
+clean_up() {
+    turn_off_water
+}
+
+# Function to print usage instructions
 usage() {
-	cat << EOF
-  water <off|on|${IT}xmys${NC}>
-  Valid values ${time_min}–${time_max}; "on" defaults to ${time_default}.
-  Example: water 1m15s
+    cat << EOF
+Usage: water <off|on|${IT}seconds${NC}>
+Valid time range is ${TIME_MIN} to ${TIME_MAX} seconds; "on" defaults to ${TIME_DEFAULT} seconds.
+Example: water 75
 EOF
 }
 
-water_off() {
-	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --off ;
-	water_state=0 ;
+# Trap signals to ensure water is turned off
+trap clean_up EXIT
+
+# Main logic
+main() {
+    if [[ $# -eq 0 ]]; then
+        echo "ERROR: No arguments provided"
+        usage
+        exit 1
+    fi
+
+    local time
+
+    case "$1" in
+        off)
+            turn_off_water
+            exit 0
+            ;;
+        on)
+            time="${TIME_DEFAULT}"
+            ;;
+        ''|*[!0-9]*)
+            echo "ERROR: Unrecognized input format"
+            usage
+            exit 1
+            ;;
+        *)
+            time="$1"
+            ;;
+    esac
+
+    # Validate that the input time is within range
+    if [[ "${time}" -ge "${TIME_MIN}" && "${time}" -le "${TIME_MAX}" ]]; then
+        water_for_time "${time}"
+    elif [[ "${WATER_BY_DEFAULT}" == true ]]; then
+        water_for_time "${TIME_DEFAULT}"
+    else
+        echo "ERROR: Input must be between ${TIME_MIN} and ${TIME_MAX} seconds"
+        usage
+        exit 1
+    fi
 }
 
-water_on() {
-	water_state=1 ;
-	"${GOE_PATH}/venv/bin/python" "${GOE_PATH}/app/sensors/pump/pump.py" --on --speed ${speed} ;
-}
-
-# Function turns on water, sleeps for input time, turns water off
-water_for_time() {
-	water_on ;
-	sleep "${1}" ;
-	water_off ;
-}
-
-# Function to double-check water is off on most exit conditions
-water_exit() {
-  if [[ ${water_state} -gt 0 ]] ; then
-		water_off ;
-	fi
-}
-
-# Function to turn off water on most error / termination conditions
-water_kill() {
-	error_code=$? ;
-	echo "Warning: Received termination signal! Stopping water..." ;
-	water_off ;
-	echo "Water stopped, exiting" ;
-	exit "${error_code}" ;
-}
-
-# Catch common error / interrupt signals and turn off the water
-## Note: SIGKILL / SIGSTOP cannot be trapped
-trap water_kill SIGABRT SIGALRM SIGHUP SIGINT SIGQUIT SIGTERM
-# Double-check water is off on any normal exit
-trap water_exit EXIT
-
-# Max-accepted valid input is "13m120s"
-if [[ ${#1} -gt 7 ]] ; then
-	echo 'ERROR: Input too many characters' ;
-  usage ;
-	exit 1 ;
-# No suffix specified; assume minutes <= 15, seconds otherwise
-elif [[ ${1} == ?(-)+([[:digit:]]) ]] ; then
-	if [[ (( ${1} -le 15 )) ]] ; then
-		time="${1}m" ;
-	else
-		time="${1}s" ;
-	fi
-# time is in xmys format
-elif [[ "${1}" =~ ^([0-9]{1,3}[ms]{1})([0-9]{1,3}s)?$ ]] ; then
-	time="${1}" ;
-elif [[ "${1}" == "on" ]] ; then
-	time=${time_default} ;
-elif [[ "${1}" == "off" ]] ; then
-	water_off ;
-	exit 0 ;
-else
-	echo 'ERROR: Unrecognized input format' ;
-	usage ;
-	exit 1 ;
-fi
-
-seconds=$(time_to_seconds "${time}") ;
-seconds_min=$(time_to_seconds "${time_min}") ;
-seconds_max=$(time_to_seconds "${time_max}") ;
-
-if [[ (( ${seconds} -ge ${seconds_min} )) && (( ${seconds} -le ${seconds_max} )) ]] ; then
-	water_for_time "${seconds}" ;
-elif [[ ${water_by_default} ]] ; then
-	water_for_time "${time_default}" ;
-else
-	echo "ERROR: Input must be between ${time_min}–${time_max}" ;
-	usage ;
-	exit 1 ;
-fi
-
-exit 0 ;
+# Run main function
+main "$@"


### PR DESCRIPTION
# feat: Add light and water commands

## Description

Adds `light` and `water` commands symlinked to corresponding `light.sh` and `water.sh` bash scripts that act as abstraction layers to make on-demand control easier, and crontab scheduling shorter, simpler, and clearer.

Note that this is a draft while I monitor these changes in production on my own device.

Fixes #61 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

I'm unsure how to add meaningful and effective tests for the bash layer in the CI-CD step for this feature, but I'm certainly open to suggestions.

- [ ] ☹️?

## Checklist

- [x] My code follows the style guidelines of this project
  - mostly; next PR is actually going to be overhauling shell scripts to better comply with POSIX and pass `shellcheck`; my new code already does this 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - Will do upon review, since these scripts are subject to change, pending review.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - See above
- [x] New and existing unit tests pass locally with my changes
