### PR TITLE
feat(mqtt): publish water depth, real pump state, and add a Refresh All button

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -33,6 +33,8 @@ from config import (
     BROKER,
     BUTTON_PIN,
     CAMERA_RESOLUTION,
+    DEFAULT_BRIGHTNESS,
+    DEFAULT_PUMP_SPEED,
     IDENTIFIER,
     IMAGE_INTERVAL_SECONDS,
     KEEP_ALIVE_INTERVAL,
@@ -87,9 +89,11 @@ pump = pump_control
 light = light_control
 distance_sensor = distance_control
 
-# default on brightness
-brightness = 50
-speed = 100
+# Default duty applied when something is switched on without an explicit level.
+# Sourced from config so DEFAULT_BRIGHTNESS/DEFAULT_PUMP_SPEED in .env take effect
+# here as well as in the persisted-state defaults.
+brightness = DEFAULT_BRIGHTNESS
+speed = DEFAULT_PUMP_SPEED
 sec_per_min = 60
 min_per_hr = 60
 
@@ -1021,7 +1025,7 @@ def on_message(client, userdata, msg):
                     return
                 if speed <= 0:
                     # A previous slider move to 0 must not leave the button inert.
-                    speed = 100
+                    speed = DEFAULT_PUMP_SPEED
                 pump.set_speed(speed)
                 _arm_pump_safety()
                 commit_pump_state(client)

--- a/mqtt.py
+++ b/mqtt.py
@@ -336,6 +336,31 @@ def publish_pump_state(client):
     logger.info("Pump is %s at %.0f%%", "ON" if level > 0 else "OFF", level)
 
 
+def commit_light_state(client):
+    """Record a commanded light change: publish it, and remember it.
+
+    ``publish_light_state`` only reports. This additionally syncs the toggle
+    flag the physical button switches against and persists the state for
+    power-loss recovery, so a change made over MQTT is not invisible to both.
+    """
+    global light_state
+    light_state = light.get_brightness() > 0
+    publish_light_state(client)
+    state_lib.save_state(light_on=light_state, brightness=brightness)
+
+
+def commit_pump_state(client):
+    """Record a commanded pump change: publish it, and remember it.
+
+    Counterpart to ``commit_light_state``; see there for why reporting alone is
+    not enough on the command paths.
+    """
+    global pump_state
+    pump_state = pump.get_speed() > 0
+    publish_pump_state(client)
+    state_lib.save_state(pump_on=pump_state, speed=speed)
+
+
 def publish_water_readings(client, distance):
     """Publish the raw airgap plus the derived depth, fill percentage and gallons.
 
@@ -992,24 +1017,24 @@ def on_message(client, userdata, msg):
                 if not water_ok_for_pump(client):
                     # Report the real (still stopped) state so HA does not sit
                     # waiting on a transition that never happened.
-                    publish_pump_state(client)
+                    commit_pump_state(client)
                     return
                 if speed <= 0:
                     # A previous slider move to 0 must not leave the button inert.
                     speed = 100
                 pump.set_speed(speed)
                 _arm_pump_safety()
-                publish_pump_state(client)
+                commit_pump_state(client)
             elif payload.upper() == "OFF":
                 pump.off()
                 _cancel_pump_safety()
-                publish_pump_state(client)
+                commit_pump_state(client)
 
         elif topic_suffix == "pump/speed/set" and payload.isdigit():
             requested = int(payload)
             # The slider must honour the same dry-run guard as the power button.
             if requested > 0 and not water_ok_for_pump(client):
-                publish_pump_state(client)
+                commit_pump_state(client)
                 return
             speed = requested
             pump.set_speed(speed)
@@ -1017,21 +1042,21 @@ def on_message(client, userdata, msg):
                 _arm_pump_safety()
             else:
                 _cancel_pump_safety()
-            publish_pump_state(client)
+            commit_pump_state(client)
 
         # === Light Logic ===
         elif topic_suffix == "light/command":
             if payload.upper() == "ON":
                 light.set_duty_cycle(brightness)
-                client.publish(BASE_TOPIC + "/light/state", "ON")
+                commit_light_state(client)
             elif payload.upper() == "OFF":
                 light.off()
-                client.publish(BASE_TOPIC + "/light/state", "OFF")
+                commit_light_state(client)
 
         elif topic_suffix == "light/brightness/set" and payload.isdigit():
             brightness = int(payload)
             light.set_duty_cycle(brightness)
-            client.publish(BASE_TOPIC + "/light/brightness/state", str(brightness))
+            commit_light_state(client)
 
         # === Water Level ===
         elif topic_suffix == "water/level/get":

--- a/mqtt.py
+++ b/mqtt.py
@@ -4,7 +4,7 @@ import signal
 import subprocess
 import sys
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Timer
 
 # import picamera
@@ -18,7 +18,7 @@ from app.lib import grow as grow_lib
 from app.lib import state as state_lib
 from app.lib.hardware import detect_model, get_pin_factory
 from app.lib.logging_config import configure_logging
-from app.lib.water import is_water_low
+from app.lib.water import gallons_remaining, is_water_low
 from app.sensors.camera import camera as camera_mod
 from app.sensors.distance.distance import MeasurementError
 from app.sensors.distance.routes import distance_control
@@ -42,11 +42,14 @@ from config import (
     MODEL,
     PASSWORD,
     PORT,
+    TANK_CAPACITY_GALLONS,
     UPPER_CAMERA_DEVICE,
     UPPER_IMAGE_PATH,
     USERNAME,
     VERSION,
     WATER_CHECK_SECONDS,
+    WATER_EMPTY_CM,
+    WATER_FULL_CM,
     WATER_LOW_CM,
 )
 
@@ -317,6 +320,63 @@ def evaluate_water_low(client):
     return distance
 
 
+def publish_light_state(client):
+    """Report the light's real duty cycle. Read-only: never changes the output."""
+    level = light.get_brightness()
+    client.publish(BASE_TOPIC + "/light/state", "ON" if level > 0 else "OFF", retain=True)
+    client.publish(BASE_TOPIC + "/light/brightness/state", str(int(round(level))), retain=True)
+    logger.info("Light is %s at %.0f%%", "ON" if level > 0 else "OFF", level)
+
+
+def publish_pump_state(client):
+    """Report the pump's real duty cycle. Read-only: never changes the output."""
+    level = pump.get_speed()
+    client.publish(BASE_TOPIC + "/pump/state", "ON" if level > 0 else "OFF", retain=True)
+    client.publish(BASE_TOPIC + "/pump/speed/state", str(int(round(level))), retain=True)
+    logger.info("Pump is %s at %.0f%%", "ON" if level > 0 else "OFF", level)
+
+
+def publish_water_readings(client, distance):
+    """Publish the raw airgap plus the derived depth, fill percentage and gallons.
+
+    The sensor reports the gap down to the water surface, so that number grows as
+    the tank drains; depth is its complement measured up from the tank floor.
+    """
+    client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
+
+    span = WATER_EMPTY_CM - WATER_FULL_CM
+    if span <= 0:
+        return
+
+    depth = max(0.0, WATER_EMPTY_CM - distance)
+    client.publish(BASE_TOPIC + "/water/depth", f"{depth:.2f}")
+
+    percent = max(0.0, min(100.0, depth / span * 100.0))
+    client.publish(BASE_TOPIC + "/water/percent", f"{percent:.0f}")
+
+    gallons = gallons_remaining(distance, WATER_FULL_CM, WATER_EMPTY_CM, TANK_CAPACITY_GALLONS)
+    if gallons is not None:
+        client.publish(BASE_TOPIC + "/water/gallons", f"{gallons:.1f}")
+
+
+def water_ok_for_pump(client):
+    """Return True when there is enough water to run the pump.
+
+    Shared by the power button and the speed slider so both paths enforce the
+    same dry-run protection. Fails *open* when the distance read itself fails,
+    matching ``is_water_low``, so a dead sensor cannot brick the pump.
+    """
+    distance = safe_distance_measure()
+    if not is_water_low(distance, WATER_LOW_CM):
+        client.publish(BASE_TOPIC + "/water/low/state", "OFF", retain=True)
+        return True
+
+    logger.warning("Water too low (%.2fcm > %.2fcm), aborting pump", distance, WATER_LOW_CM)
+    flash_lights()
+    client.publish(BASE_TOPIC + "/water/low/state", "ON", retain=True)
+    return False
+
+
 def publish_water_low_mode(client):
     if WATER_LOW_CM not in (None, 0):
         mode = "Enabled"
@@ -448,6 +508,78 @@ def send_discovery_messages(client):
     }
     pub(TEMP_CONFIG_TOPIC, temp_config_payload)
 
+    # Config for Water Depth (complement of the raw airgap; rises as you fill)
+    TEMP_CONFIG_TOPIC = "homeassistant/sensor/gardyn/" + IDENTIFIER + "_water_depth/config"
+    temp_config_payload = {
+        "name": "Water Depth",
+        "unique_id": IDENTIFIER + "_water_depth",
+        "state_topic": BASE_TOPIC + "/water/depth",
+        "unit_of_measurement": "cm",
+        "device_class": "distance",
+        "icon": "mdi:cup-water",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
+    # Config for Water Remaining (percentage of usable capacity)
+    TEMP_CONFIG_TOPIC = "homeassistant/sensor/gardyn/" + IDENTIFIER + "_water_percent/config"
+    temp_config_payload = {
+        "name": "Water Remaining",
+        "unique_id": IDENTIFIER + "_water_percent",
+        "state_topic": BASE_TOPIC + "/water/percent",
+        "unit_of_measurement": "%",
+        "icon": "mdi:water-percent",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
+    # Config for Water Gallons (uses the shared gallons_remaining calibration)
+    TEMP_CONFIG_TOPIC = "homeassistant/sensor/gardyn/" + IDENTIFIER + "_water_gallons/config"
+    temp_config_payload = {
+        "name": "Water Gallons",
+        "unique_id": IDENTIFIER + "_water_gallons",
+        "state_topic": BASE_TOPIC + "/water/gallons",
+        "unit_of_measurement": "gal",
+        "icon": "mdi:water",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
+    # Config for Refresh All Button
+    TEMP_CONFIG_TOPIC = "homeassistant/button/gardyn/" + IDENTIFIER + "_refresh_all/config"
+    temp_config_payload = {
+        "name": "Refresh All",
+        "unique_id": IDENTIFIER + "_refresh_all",
+        "command_topic": BASE_TOPIC + "/refresh/all",
+        "payload_press": "PRESS",
+        "icon": "mdi:refresh",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
+    # Config for Refresh Status
+    TEMP_CONFIG_TOPIC = "homeassistant/sensor/gardyn/" + IDENTIFIER + "_refresh_status/config"
+    temp_config_payload = {
+        "name": "Refresh Status",
+        "unique_id": IDENTIFIER + "_refresh_status",
+        "state_topic": BASE_TOPIC + "/refresh/status",
+        "icon": "mdi:clipboard-check-outline",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
+    # Config for Last Refresh timestamp
+    TEMP_CONFIG_TOPIC = "homeassistant/sensor/gardyn/" + IDENTIFIER + "_refresh_last/config"
+    temp_config_payload = {
+        "name": "Last Refresh",
+        "unique_id": IDENTIFIER + "_refresh_last",
+        "state_topic": BASE_TOPIC + "/refresh/last",
+        "device_class": "timestamp",
+        "icon": "mdi:clock-check-outline",
+        "device": device_info,
+    }
+    pub(TEMP_CONFIG_TOPIC, temp_config_payload)
+
     # Config for Water Low Binary Sensor
     TEMP_CONFIG_TOPIC = f"homeassistant/binary_sensor/gardyn/{IDENTIFIER}_water_low/config"
     temp_config_payload = {
@@ -472,7 +604,7 @@ def send_discovery_messages(client):
         "state_topic": BASE_TOPIC + "/water/low/cm",
         "command_topic": BASE_TOPIC + "/water/low/cm/set",
         "min": 0,
-        "max": 15,
+        "max": 25,
         "step": 0.5,
         "unit_of_measurement": "cm",
         "device_class": "distance",
@@ -827,6 +959,13 @@ def on_connect(client, userdata, flags, rc, properties=None):
     update_water_low_state(client)
     publish_grow_state(client)
     publish_schedule_state(client)
+    # Report the actuators' true duty cycle so HA never shows a stale retained
+    # value. Read-only; restore_actuator_state() owns any actual restoration.
+    try:
+        publish_light_state(client)
+        publish_pump_state(client)
+    except Exception:
+        logger.exception("Could not publish initial actuator state")
 
 
 def on_message(client, userdata, msg):
@@ -850,33 +989,35 @@ def on_message(client, userdata, msg):
         # === Pump Logic ===
         if topic_suffix == "pump/command":
             if payload.upper() == "ON":
-                if WATER_LOW_CM not in (None, 0):
-                    distance = safe_distance_measure()
-                    if distance is not None and distance > WATER_LOW_CM:
-                        logger.warning(
-                            f"Water too low ({distance:.2f}cm > {WATER_LOW_CM:.2f}cm), aborting pump"
-                        )
-                        flash_lights()
-                        client.publish(BASE_TOPIC + "/water/low/state", "ON", retain=True)
-                        return
-                    else:
-                        client.publish(BASE_TOPIC + "/water/low/state", "OFF", retain=True)
+                if not water_ok_for_pump(client):
+                    # Report the real (still stopped) state so HA does not sit
+                    # waiting on a transition that never happened.
+                    publish_pump_state(client)
+                    return
+                if speed <= 0:
+                    # A previous slider move to 0 must not leave the button inert.
+                    speed = 100
                 pump.set_speed(speed)
                 _arm_pump_safety()
-                client.publish(BASE_TOPIC + "/pump/state", "ON")
+                publish_pump_state(client)
             elif payload.upper() == "OFF":
                 pump.off()
                 _cancel_pump_safety()
-                client.publish(BASE_TOPIC + "/pump/state", "OFF")
+                publish_pump_state(client)
 
         elif topic_suffix == "pump/speed/set" and payload.isdigit():
-            speed = int(payload)
+            requested = int(payload)
+            # The slider must honour the same dry-run guard as the power button.
+            if requested > 0 and not water_ok_for_pump(client):
+                publish_pump_state(client)
+                return
+            speed = requested
             pump.set_speed(speed)
             if speed > 0:
                 _arm_pump_safety()
             else:
                 _cancel_pump_safety()
-            client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
+            publish_pump_state(client)
 
         # === Light Logic ===
         elif topic_suffix == "light/command":
@@ -896,7 +1037,11 @@ def on_message(client, userdata, msg):
         elif topic_suffix == "water/level/get":
             distance = safe_distance_measure()
             if distance is not None:
-                client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
+                publish_water_readings(client, distance)
+
+        elif topic_suffix == "refresh/all":
+            # Camera capture takes several seconds; never block the MQTT loop.
+            threading.Thread(target=refresh_all, args=(client,), daemon=True).start()
 
         elif topic_suffix == "water/low/cm/set":
             try:
@@ -1005,76 +1150,114 @@ def publish_water_level(client):
         if distance is None:
             distance = measure_distance_median()
         if distance is not None:
-            logger.info(f"Publishing Water Level: {distance:.2f}cm")
-            client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
+            logger.info(f"Publishing Water Level: {distance:.2f}cm airgap")
+            publish_water_readings(client, distance)
         sleep(WATER_CHECK_SECONDS)
+
+
+def capture_and_publish_images(client):
+    """Capture one frame from each camera, archive it, and publish both JPEGs."""
+    # Capture upper camera image
+    subprocess.check_call(
+        [
+            "fswebcam",
+            "-d",
+            UPPER_CAMERA_DEVICE,
+            "-r",
+            CAMERA_RESOLUTION,
+            "-S",
+            "2",
+            "-F",
+            "2",
+            "--no-banner",
+            UPPER_IMAGE_PATH,
+        ]
+    )
+    logger.info(f"Captured image from upper camera ({UPPER_CAMERA_DEVICE})")
+
+    # Capture lower camera image
+    subprocess.check_call(
+        [
+            "fswebcam",
+            "-d",
+            LOWER_CAMERA_DEVICE,
+            "-r",
+            CAMERA_RESOLUTION,
+            "-S",
+            "2",
+            "-F",
+            "2",
+            "--no-banner",
+            LOWER_IMAGE_PATH,
+        ]
+    )
+    logger.info(f"Captured image from lower camera ({LOWER_CAMERA_DEVICE})")
+
+    # Archive timestamped frames for timelapse assembly.
+    camera_mod.archive_frame(UPPER_IMAGE_PATH, "upper")
+    camera_mod.archive_frame(LOWER_IMAGE_PATH, "lower")
+
+    with open(UPPER_IMAGE_PATH, "rb") as f:
+        client.publish(BASE_TOPIC + "/image/upper_camera", payload=f.read(), qos=0, retain=True)
+        logger.info("Published image to /image/upper_camera")
+
+    with open(LOWER_IMAGE_PATH, "rb") as f:
+        client.publish(BASE_TOPIC + "/image/lower_camera", payload=f.read(), qos=0, retain=True)
+        logger.info("Published image to /image/lower_camera")
+
+
+def refresh_all(client):
+    """Force an immediate read of every sensor, actuator and camera.
+
+    Each step is isolated so one flaky sensor (the AM2320 in particular) cannot
+    stop the rest of the refresh. The actuator steps are read-only: they report
+    the live duty cycle of the light and pump without changing either.
+    """
+    logger.info("Refresh All: starting forced poll")
+
+    steps = (
+        ("water level", lambda: publish_water_readings(client, safe_distance_measure())),
+        ("water low state", lambda: update_water_low_state(client)),
+        (
+            "pcb temperature",
+            lambda: client.publish(BASE_TOPIC + "/pcb/temperature", f"{get_pcb_temperature():.2f}"),
+        ),
+        (
+            "temperature",
+            lambda: client.publish(BASE_TOPIC + "/temperature", f"{temperature_sensor.read():.2f}"),
+        ),
+        (
+            "humidity",
+            lambda: client.publish(BASE_TOPIC + "/humidity", f"{humidity_sensor.read():.2f}"),
+        ),
+        ("light state", lambda: publish_light_state(client)),
+        ("pump state", lambda: publish_pump_state(client)),
+        ("cameras", lambda: capture_and_publish_images(client)),
+    )
+
+    failed = []
+    for name, step in steps:
+        try:
+            step()
+            logger.info("Refresh All: %s OK", name)
+        except Exception as exc:
+            failed.append(name)
+            logger.error("Refresh All: %s FAILED (%s)", name, exc)
+
+    status = "OK" if not failed else "PARTIAL: " + ", ".join(failed) + " failed"
+    client.publish(BASE_TOPIC + "/refresh/status", status, retain=True)
+    client.publish(
+        BASE_TOPIC + "/refresh/last",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        retain=True,
+    )
+    logger.info("Refresh All: finished (%s)", status)
 
 
 def publish_images(client):
     while True:
         try:
-            # Capture upper camera image
-            subprocess.check_call(
-                [
-                    "fswebcam",
-                    "-d",
-                    UPPER_CAMERA_DEVICE,
-                    "-r",
-                    CAMERA_RESOLUTION,
-                    "-S",
-                    "2",
-                    "-F",
-                    "2",
-                    "--no-banner",
-                    UPPER_IMAGE_PATH,
-                ]
-            )
-            logger.info(f"Captured image from upper camera ({UPPER_CAMERA_DEVICE})")
-
-            # Capture lower camera image
-            subprocess.check_call(
-                [
-                    "fswebcam",
-                    "-d",
-                    LOWER_CAMERA_DEVICE,
-                    "-r",
-                    CAMERA_RESOLUTION,
-                    "-S",
-                    "2",
-                    "-F",
-                    "2",
-                    "--no-banner",
-                    LOWER_IMAGE_PATH,
-                ]
-            )
-            logger.info(f"Captured image from lower camera ({LOWER_CAMERA_DEVICE})")
-
-            # Archive timestamped frames for timelapse assembly.
-            camera_mod.archive_frame(UPPER_IMAGE_PATH, "upper")
-            camera_mod.archive_frame(LOWER_IMAGE_PATH, "lower")
-
-            # Publish upper camera image
-            with open(UPPER_IMAGE_PATH, "rb") as f:
-                upper_cam_jpeg_data = f.read()  # Read as raw binary
-                client.publish(
-                    BASE_TOPIC + "/image/upper_camera",
-                    payload=upper_cam_jpeg_data,
-                    qos=0,
-                    retain=True,
-                )
-                logger.info("Published image to /image/upper_camera")
-
-            # Publish lower camera image
-            with open(LOWER_IMAGE_PATH, "rb") as f:
-                lower_cam_jpeg_data = f.read()  # Read as raw binary
-                client.publish(
-                    BASE_TOPIC + "/image/lower_camera",
-                    payload=lower_cam_jpeg_data,
-                    qos=0,
-                    retain=True,
-                )
-                logger.info("Published image to /image/lower_camera")
-
+            capture_and_publish_images(client)
         except subprocess.CalledProcessError as e:
             logger.error(f"Camera capture failed: {e}")
         except Exception:

--- a/tests/test_mqtt_control.py
+++ b/tests/test_mqtt_control.py
@@ -38,6 +38,8 @@ class MqttControlTestCase(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.config.SCHEDULE_FILE = os.path.join(self.tmp, "sched.json")
         self.config.GROW_STATE_FILE = os.path.join(self.tmp, "grow.json")
+        # Actuator state is persisted too; keep it out of the developer's home.
+        self.config.STATE_FILE = os.path.join(self.tmp, "state.json")
         # Never touch the host crontab.
         self.mqtt.sched_lib._read_crontab = lambda: []
         self.mqtt.sched_lib._write_crontab = lambda lines: None
@@ -136,6 +138,45 @@ class MqttControlTestCase(unittest.TestCase):
         self.send("grow/stage/set", "harvest")
         self.send("grow/start/set", "PRESS")
         self.assertEqual(self.mqtt.grow_lib.load_state()["stage"], "germination")
+
+    # --- actuator commands are persisted and tracked ---
+    # A command arriving over MQTT has to leave the same trace a physical button
+    # press does, or power-loss recovery restores a stale value and the button's
+    # next toggle fights whatever Home Assistant last did.
+    def test_light_command_persists_and_tracks_state(self):
+        self.send("light/command", "ON")
+        self.assertTrue(self.mqtt.state_lib.load_state()["light_on"])
+        self.assertTrue(self.mqtt.light_state)
+        self.assertIn("ON", self.published_for("light/state"))
+
+        self.send("light/command", "OFF")
+        self.assertFalse(self.mqtt.state_lib.load_state()["light_on"])
+        self.assertFalse(self.mqtt.light_state)
+
+    def test_light_brightness_persists(self):
+        self.send("light/brightness/set", "42")
+        self.assertEqual(self.mqtt.state_lib.load_state()["brightness"], 42)
+
+    def test_pump_speed_persists_and_tracks_state(self):
+        self.send("pump/speed/set", "60")
+        saved = self.mqtt.state_lib.load_state()
+        self.assertEqual(saved["speed"], 60)
+        self.assertTrue(saved["pump_on"])
+        self.assertTrue(self.mqtt.pump_state)
+
+        self.send("pump/speed/set", "0")
+        self.assertFalse(self.mqtt.state_lib.load_state()["pump_on"])
+        self.assertFalse(self.mqtt.pump_state)
+
+    def test_pump_speed_set_publishes_on_off_state(self):
+        """The slider must drive pump/state, not just pump/speed/state.
+
+        Without this HA shows the pump OFF while it runs, and then refuses to
+        send further brightness commands to what it believes is an off light.
+        """
+        self.send("pump/speed/set", "55")
+        self.assertIn("ON", self.published_for("pump/state"))
+        self.assertIn("55", self.published_for("pump/speed/state"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Three related gaps in the MQTT service, found while running 2.0.0 on a Gardyn 1.0 (Pi Zero W), plus a small entity-range fix. No new config and no new dependencies — the water work reuses primitives already in the tree.

**1. Water level reads inverted, and the existing calibration is unused by MQTT.**
The ultrasonic sensor reports the *airgap* down to the water surface, so the `Water Level` entity climbs as the tank drains. `config.py` already carries `WATER_FULL_CM` / `WATER_EMPTY_CM` / `TANK_CAPACITY_GALLONS`, and `app/lib/water.py` already implements and tests `gallons_remaining()` — but those feed only the REST API (`app/sensors/distance/routes.py`) and never reach Home Assistant. This publishes the complement as **Water Depth**, plus **Water Remaining (%)** and **Water Gallons**, reusing the existing helper rather than adding a parallel implementation.

**2. Pump state never reaches Home Assistant.**
`pump/speed/set` publishes `pump/speed/state` but never `pump/state`. HA therefore shows the pump OFF while it is running, and because HA treats the entity as off, its brightness slider stops responding until the service restarts. Both pump paths now publish state read back from the driver, so what HA displays cannot drift from the hardware.

**3. The dry-run guard is bypassable.**
The water-low check guards `pump/command` but not `pump/speed/set`, so setting a speed starts the pump with no protection at all. This is worse than it sounds in practice: because symptom 2 makes the power button appear broken, the slider is exactly what a user reaches for. Both paths now share `water_ok_for_pump()`.

**Refresh All** is a new button entity that force-polls every sensor and both cameras on demand, with **Refresh Status** and **Last Refresh** for feedback. Steps are isolated so one flaky sensor degrades the run to `PARTIAL` rather than aborting it — useful with the AM2320, which NAKs its first wake-up probe. Camera capture moves into `capture_and_publish_images()` so the button and the interval loop share one implementation, and it runs on a worker thread so the several-second capture never blocks the MQTT loop.

Finally, the water-low threshold `number` entity is capped at `max: 15` while the default `WATER_EMPTY_CM` is `20` — the slider cannot express a threshold near its own documented empty distance. Raised to 25.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `python -m unittest discover -t . -s tests -p 'test_*.py'` — 126 passed
- [x] `ruff check .` and `black --check .` — clean
- [x] Deployed to a Gardyn 1.0 / Pi Zero W (armv6l, Python 3.13): service restarts clean, connects, restores actuator state, no traceback
- [x] End-to-end against a live Mosquitto broker: `water/level 5.49`, `water/depth 17.56`, `water/percent 96`, `water/gallons 4.8`, `refresh/status OK`
- [x] Depth calibration validated against two independent physical measurements — at a 14.16 cm airgap a ruler read 3.5" and the model predicted 49%; after filling, it read 100%
- [x] Refresh All confirmed read-only for actuators — reports light and pump duty without changing either
- [x] Non-actuating pump paths (`speed/set 0`, `command OFF`) confirmed to publish real state
- [x] Verified every pre-existing HA `unique_id` is unchanged, so no existing entity is renamed

**Not tested:** the pump ON path, which energizes the motor.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Notes for reviewers

- `water_ok_for_pump()` deliberately **fails open** when the distance read fails, matching the existing `is_water_low()` contract, so a dead sensor cannot brick the pump. Happy to invert this if you'd prefer fail-closed.
- Six entities are added (`water_depth`, `water_percent`, `water_gallons`, `refresh_all`, `refresh_status`, `refresh_last`). Nothing existing is renamed or removed.
- `.env-dist` is unchanged — the water constants it documents already existed.
- Related to #33 and #86, though I haven't verified this closes either, so I've left them unlinked.


---

### Related issues
Addresses **#86** (low water status not updating) and contributes to **#4** (water notifications).

Two distinct contributions there, described in the issue comments: `water_ok_for_pump()` refreshes the retained `water/low/state` on **every pump command path** (power button and speed slider), rather than only on the `WATER_CHECK_SECONDS` timer; and the reported water state moves from a bare sensor-to-surface airgap to calibrated **depth / fill % / gallons**. `main` already debounces and retains the low-water alert, so this complements that work rather than replacing it.


---

### Overlap note
**`mqtt.py` overlaps substantially with #104.** Both rewrite large parts of it (water publishing, discovery, `on_message`), so whichever merges second will need a rebase. That is unavoidable — the work genuinely overlaps — but #104 was deliberately written not to depend on the helpers this PR adds, so either merge order works.
