### PR TITLE
fix(web): API-key prompt, actuator state, camera auth, and timelapse usability

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -70,6 +70,11 @@ IMAGE_INTERVAL_SECONDS=3600
 # TIMELAPSE_DIR=
 TIMELAPSE_MAX_FRAMES=720
 TIMELAPSE_FPS=12
+# Frames below which the UI warns there is little history yet (168 = 7 days hourly).
+# A build still works at any count; short archives are just slowed down to run for
+# roughly TIMELAPSE_TARGET_SECONDS instead of flashing past at the full frame rate.
+TIMELAPSE_MIN_FRAMES=168
+TIMELAPSE_TARGET_SECONDS=10
 
 # ── REST API auth (optional) ──
 # When set, non-localhost requests must send X-API-Key: <key>.

--- a/app/sensors/camera/camera.py
+++ b/app/sensors/camera/camera.py
@@ -76,18 +76,58 @@ def archive_frame(src_path, cam):
         logger.error("Timelapse archive failed for %s: %s", cam, exc)
 
 
+def _frame_stamp(path):
+    """Parse the capture time back out of an archived frame's filename."""
+    try:
+        name = os.path.basename(path).split(".")[0]
+        return datetime.datetime.strptime(name, "%Y%m%d-%H%M%S").isoformat()
+    except ValueError:
+        return None
+
+
+def framerate_for(count):
+    """Frame rate to assemble ``count`` frames at.
+
+    A week of hourly frames at the full rate is only a few seconds long, so slow
+    short archives down toward TIMELAPSE_TARGET_SECONDS rather than letting them
+    flash past. Never below 1fps, never above TIMELAPSE_FPS.
+    """
+    target = count / float(max(1, config.TIMELAPSE_TARGET_SECONDS))
+    return max(1, min(config.TIMELAPSE_FPS, int(round(target))))
+
+
+def clip_seconds(count):
+    """How long the assembled clip would run, at the rate framerate_for picks."""
+    if not count:
+        return 0.0
+    return round(count / float(framerate_for(count)), 1)
+
+
+def frame_stats(cam):
+    """Archived frame count plus first/last capture times, so the UI can say how
+    much history exists before a build is worth doing."""
+    frames = sorted(glob.glob(os.path.join(_frames_dir(cam), "*.jpg")))
+    return {
+        "frames": len(frames),
+        "first": _frame_stamp(frames[0]) if frames else None,
+        "last": _frame_stamp(frames[-1]) if frames else None,
+        "seconds": clip_seconds(len(frames)),
+    }
+
+
 def generate_timelapse(cam):
     """Assemble the archived frames for ``cam`` into an mp4. Raises
     FileNotFoundError if no frames have been archived yet."""
     folder = _frames_dir(cam)
-    if not glob.glob(os.path.join(folder, "*.jpg")):
+    frames = glob.glob(os.path.join(folder, "*.jpg"))
+    if not frames:
         raise FileNotFoundError("no frames archived yet")
     out = timelapse_path(cam)
     cmd = [
         "ffmpeg",
         "-y",
         "-framerate",
-        str(config.TIMELAPSE_FPS),
+        str(framerate_for(len(frames))),
         "-pattern_type",
         "glob",
         "-i",

--- a/app/sensors/camera/routes.py
+++ b/app/sensors/camera/routes.py
@@ -43,6 +43,20 @@ def get_timelapse(cam):
     return send_file(path, mimetype="video/mp4")
 
 
+@camera_blueprint.route("/timelapse/<cam>/status", methods=["GET"])
+def timelapse_status(cam):
+    """How much history is archived, so the UI can explain an empty player
+    instead of showing a blank video box."""
+    if cam not in camera.CAMERAS:
+        return jsonify(error="unknown camera"), 400
+    stats = camera.frame_stats(cam)
+    stats["min_frames"] = config.TIMELAPSE_MIN_FRAMES
+    stats["ready"] = stats["frames"] >= config.TIMELAPSE_MIN_FRAMES
+    stats["has_video"] = os.path.exists(camera.timelapse_path(cam))
+    stats["interval_seconds"] = config.IMAGE_INTERVAL_SECONDS
+    return jsonify(stats)
+
+
 @camera_blueprint.route("/timelapse/<cam>", methods=["POST"])
 def make_timelapse(cam):
     if cam not in camera.CAMERAS:

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -523,23 +523,39 @@
       } catch { $("meta").textContent = "offline"; conn(false); }
     }
 
+    // <img src> and <video src> are browser-issued requests that cannot carry the
+    // X-API-Key header, so they 401 whenever GARDEN_API_KEY is set. Fetch the bytes
+    // ourselves and hand the element a blob URL instead. Old URLs are revoked so the
+    // live-refresh loop does not leak one blob per frame.
+    async function loadMedia(id, path, ms) {
+      const el = $(id);
+      try {
+        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 20000);
+        if (r.status === 401) { needKey(); return false; }
+        if (!r.ok) return false;
+        const url = URL.createObjectURL(await r.blob());
+        if (el.dataset.url) URL.revokeObjectURL(el.dataset.url);
+        el.dataset.url = url; el.src = url;
+        if (el.tagName === "VIDEO") el.load();
+        return true;
+      } catch { return false; }
+    }
     function loadCams() {
-      $("cam-upper").src = "/camera/upper?t=" + Date.now();
-      $("cam-lower").src = "/camera/lower?t=" + Date.now();
+      loadMedia("cam-upper", "/camera/upper");
+      loadMedia("cam-lower", "/camera/lower");
     }
     function toggleCamAuto() {
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }
       else { clearInterval(camTimer); camTimer = null; }
     }
     function loadTimelapses() {
-      ["upper", "lower"].forEach(c => { $("tl-" + c).src = "/camera/timelapse/" + c + "?t=" + Date.now(); });
+      ["upper", "lower"].forEach(c => loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000));
     }
     async function makeTimelapse(cam) {
-      toast("Building " + cam + " timelapse… (can take a minute)");
+      toast("Building " + cam + " timelapse (can take a minute)");
       const r = await post("/camera/timelapse/" + cam);
-      if (r && !r.error) { const v = $("tl-" + cam); v.src = "/camera/timelapse/" + cam + "?t=" + Date.now(); v.load(); }
+      if (r && !r.error) await loadMedia("tl-" + cam, "/camera/timelapse/" + cam, 60000);
     }
-
     // A range input with no value attribute parks at its midpoint, so the UI used
     // to claim 50% while the hardware was off. Seed both the slider and its label
     // from the real value.

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -530,7 +530,7 @@
     async function loadMedia(id, path, ms) {
       const el = $(id);
       try {
-        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 20000);
+        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 30000);
         if (r.status === 401) { needKey(); return false; }
         if (!r.ok) return false;
         const url = URL.createObjectURL(await r.blob());
@@ -540,9 +540,17 @@
         return true;
       } catch { return false; }
     }
-    function loadCams() {
-      loadMedia("cam-upper", "/camera/upper");
-      loadMedia("cam-lower", "/camera/lower");
+    // Two USB captures at once contend on the Pi's bus (measured 17-20s each in
+    // parallel vs 2.5-3s sequentially), so take them one at a time and skip a tick
+    // rather than stacking passes when the interval is shorter than a full cycle.
+    let camBusy = false;
+    async function loadCams() {
+      if (camBusy) return;
+      camBusy = true;
+      try {
+        await loadMedia("cam-upper", "/camera/upper", 30000);
+        await loadMedia("cam-lower", "/camera/lower", 30000);
+      } finally { camBusy = false; }
     }
     function toggleCamAuto() {
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -298,9 +298,9 @@
       </div>
       <div class="row">
         <label>Brightness</label>
-        <input type="range" min="0" max="100" id="brightness" oninput="lbl('brightness')"
+        <input type="range" min="0" max="100" value="0" id="brightness" oninput="lbl('brightness')"
                onchange="post('/light/brightness', {value:+this.value}); setActive('light', +this.value>0)">
-        <span class="pct" id="brightness-val">50%</span>
+        <span class="pct" id="brightness-val">0%</span>
       </div>
     </div>
 
@@ -312,9 +312,9 @@
       </div>
       <div class="row">
         <label>Speed</label>
-        <input type="range" min="0" max="100" id="speed" oninput="lbl('speed')"
+        <input type="range" min="0" max="100" value="0" id="speed" oninput="lbl('speed')"
                onchange="post('/pump/speed', {value:+this.value}); setActive('pump', +this.value>0)">
-        <span class="pct" id="speed-val">100%</span>
+        <span class="pct" id="speed-val">0%</span>
       </div>
       <div class="row">
         <label>Run for</label>
@@ -540,9 +540,13 @@
       if (r && !r.error) { const v = $("tl-" + cam); v.src = "/camera/timelapse/" + cam + "?t=" + Date.now(); v.load(); }
     }
 
+    // A range input with no value attribute parks at its midpoint, so the UI used
+    // to claim 50% while the hardware was off. Seed both the slider and its label
+    // from the real value.
+    function setSlider(id, v) { $(id).value = Math.round(+v || 0); lbl(id); }
     async function syncToggles() {
-      try { setActive("light", ((await get("/light/brightness")).value || 0) > 0); } catch {}
-      try { setActive("pump", ((await get("/pump/speed")).value || 0) > 0); } catch {}
+      try { setSlider("brightness", (await get("/light/brightness")).value); setActive("light", +$("brightness").value > 0); } catch {}
+      try { setSlider("speed", (await get("/pump/speed")).value); setActive("pump", +$("speed").value > 0); } catch {}
     }
 
     async function loadGrow() {
@@ -799,7 +803,7 @@
       });
     }
     function toggleSettings() { $("settings").classList.toggle("open"); $("api-key").value = API_KEY; }
-    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); }
+    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); syncToggles(); }
 
     setupCollapsible();
     $("theme-btn").textContent = document.documentElement.dataset.theme === "dark" ? "🌙" : "☀️";

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -171,6 +171,7 @@
     /* Per-pod plant tracking */
     .pods { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
     @media (max-width:640px){ .pods { grid-template-columns:1fr 1fr; } }
+    .tlnote { font-size:.62rem; line-height:1.4; padding:4px 2px 0; }
     .pod { border:1px solid var(--line); background:var(--surface-2); border-radius:10px; padding:8px; }
     .pod .pn { font-size:.6rem; color:var(--faint); font-weight:700; letter-spacing:.05em; }
     .pod input { width:100%; margin:4px 0; font-size:.8rem; padding:4px 6px; border-radius:7px; }
@@ -341,8 +342,8 @@
         </span>
       </h2>
       <div class="cams">
-        <figure class="cam"><video id="tl-upper" controls preload="none" playsinline muted loop></video><figcaption>Upper timelapse</figcaption></figure>
-        <figure class="cam"><video id="tl-lower" controls preload="none" playsinline muted loop></video><figcaption>Lower timelapse</figcaption></figure>
+        <figure class="cam"><video id="tl-upper" controls preload="none" playsinline muted loop></video><figcaption>Upper timelapse</figcaption><div class="tlnote muted" id="tl-note-upper"></div></figure>
+        <figure class="cam"><video id="tl-lower" controls preload="none" playsinline muted loop></video><figcaption>Lower timelapse</figcaption><div class="tlnote muted" id="tl-note-lower"></div></figure>
       </div>
     </div>
 
@@ -564,13 +565,32 @@
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }
       else { clearInterval(camTimer); camTimer = null; }
     }
-    function loadTimelapses() {
-      ["upper", "lower"].forEach(c => loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000));
+    // A build works at any frame count, but an archive only hours old makes a
+    // clip barely a second long, so say how much history exists rather than
+    // leaving an empty player with no explanation.
+    async function loadTimelapses() {
+      for (const c of ["upper", "lower"]) {
+        const note = $("tl-note-" + c);
+        let st = null;
+        try { st = await get("/camera/timelapse/" + c + "/status"); } catch { }
+        if (!st) { note.textContent = ""; continue; }
+        if (st.has_video) await loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000);
+        if (!st.frames) {
+          note.textContent = "No frames archived yet - one is captured automatically every "
+            + Math.round(st.interval_seconds / 60) + " min.";
+          continue;
+        }
+        const since = st.first ? new Date(st.first).toLocaleDateString() : "?";
+        const days = Math.max(1, Math.round(st.min_frames * st.interval_seconds / 86400));
+        note.textContent = st.frames + " frames since " + since + " - builds a ~" + st.seconds + "s clip"
+          + (st.ready ? "." : ". Recommended from " + st.min_frames + " frames (~" + days + " days).")
+          + (st.has_video ? "" : " No clip built yet.");
+      }
     }
     async function makeTimelapse(cam) {
       toast("Building " + cam + " timelapse (can take a minute)");
       const r = await post("/camera/timelapse/" + cam);
-      if (r && !r.error) await loadMedia("tl-" + cam, "/camera/timelapse/" + cam, 60000);
+      if (r && !r.error) await loadTimelapses();
     }
     // A range input with no value attribute parks at its midpoint, so the UI used
     // to claim 50% while the hardware was off. Seed both the slider and its label

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -232,6 +232,11 @@
 
     <div id="alerts"></div>
 
+    <div id="keyalert" class="alert-banner" style="display:none">
+      <span>API key required - this Pi sets <code>GARDEN_API_KEY</code>. Enter it in Settings to load data.</span>
+      <button class="btn" onclick="needKey()">Enter key</button>
+    </div>
+
     <div class="card" id="settings">
       <h2>Settings</h2>
       <div class="row">
@@ -421,6 +426,19 @@
     function toast(msg, err) { const t = $("toast"); t.textContent = msg; t.className = "show" + (err ? " err" : ""); setTimeout(() => t.className = "", 1600); }
     function conn(ok) { $("conn").className = "dot " + (ok ? "ok" : "bad"); }
 
+    // A 401 means the firmware has GARDEN_API_KEY set but this browser has no key
+    // (or a stale one). Surface it instead of leaving every tile blank - /health is
+    // exempt from auth, so the connection dot stays green and hides the real cause.
+    let keyPrompted = false;
+    function needKey() {
+      $("keyalert").style.display = "flex";
+      if (keyPrompted) return;
+      keyPrompted = true;
+      $("settings").classList.add("open");
+      $("api-key").value = API_KEY;
+      $("api-key").focus();
+    }
+
     // fetch with a timeout so a hung/unreachable Pi never freezes the UI.
     async function fetchT(path, opts, ms) {
       const ctrl = new AbortController();
@@ -430,6 +448,7 @@
     }
     async function get(path) {
       const r = await fetchT(path, { headers: headers() });
+      if (r.status === 401) { needKey(); throw new Error(401); }
       if (!r.ok) throw new Error(r.status);
       conn(true); return r.json();
     }
@@ -437,6 +456,7 @@
       try {
         const r = await fetchT(path, { method: "POST", headers: headers({ "Content-Type": "application/json" }), body: JSON.stringify(body || {}) });
         let d = {}; try { d = await r.json(); } catch {}
+        if (r.status === 401) needKey();
         conn(r.ok); toast(d.message || d.error || (r.ok ? "ok" : "error " + r.status), !r.ok); return d;
       } catch (e) { conn(false); toast(e.name === "AbortError" ? "request timed out" : "error: " + e.message, true); }
     }
@@ -779,7 +799,7 @@
       });
     }
     function toggleSettings() { $("settings").classList.toggle("open"); $("api-key").value = API_KEY; }
-    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); toast("key saved"); loadSystem(); refresh(); }
+    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); }
 
     setupCollapsible();
     $("theme-btn").textContent = document.documentElement.dataset.theme === "dark" ? "🌙" : "☀️";

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -331,8 +331,8 @@
         </span>
       </h2>
       <div class="cams">
-        <figure class="cam"><img id="cam-upper" alt="upper camera"><figcaption>Upper</figcaption></figure>
-        <figure class="cam"><img id="cam-lower" alt="lower camera"><figcaption>Lower</figcaption></figure>
+        <figure class="cam"><img id="cam-upper" alt="upper camera"><figcaption id="cap-upper">Upper</figcaption></figure>
+        <figure class="cam"><img id="cam-lower" alt="lower camera"><figcaption id="cap-lower">Lower</figcaption></figure>
       </div>
       <h2 style="margin-top:18px">Timelapse
         <span style="display:flex; gap:8px">
@@ -543,13 +543,21 @@
     // Two USB captures at once contend on the Pi's bus (measured 17-20s each in
     // parallel vs 2.5-3s sequentially), so take them one at a time and skip a tick
     // rather than stacking passes when the interval is shorter than a full cycle.
+    // Consecutive frames of a stationary tower look identical, so without a
+    // timestamp there is no way to tell a refresh landed.
+    function stampCam(which, ok) {
+      const el = $("cap-" + which);
+      const name = which === "upper" ? "Upper" : "Lower";
+      el.textContent = name + " \u00b7 " + (ok ? new Date().toLocaleTimeString() : "capture failed");
+      el.style.color = ok ? "" : "var(--red)";
+    }
     let camBusy = false;
     async function loadCams() {
       if (camBusy) return;
       camBusy = true;
       try {
-        await loadMedia("cam-upper", "/camera/upper", 30000);
-        await loadMedia("cam-lower", "/camera/lower", 30000);
+        stampCam("upper", await loadMedia("cam-upper", "/camera/upper", 30000));
+        stampCam("lower", await loadMedia("cam-lower", "/camera/lower", 30000));
       } finally { camBusy = false; }
     }
     function toggleCamAuto() {

--- a/config.py
+++ b/config.py
@@ -146,6 +146,12 @@ TIMELAPSE_DIR = os.getenv(
 )
 TIMELAPSE_MAX_FRAMES = _get_int("TIMELAPSE_MAX_FRAMES", 720)
 TIMELAPSE_FPS = _get_int("TIMELAPSE_FPS", 12)
+# A build works with any number of frames, but a short archive played at the full
+# frame rate flashes past. Frame rate is scaled down to stretch small archives to
+# roughly TIMELAPSE_TARGET_SECONDS; MIN_FRAMES is only the point at which the UI
+# stops warning that there is not much history yet (168 = 7 days of hourly frames).
+TIMELAPSE_MIN_FRAMES = _get_int("TIMELAPSE_MIN_FRAMES", 168)
+TIMELAPSE_TARGET_SECONDS = _get_int("TIMELAPSE_TARGET_SECONDS", 10)
 
 # ---------------------------------------------------------------------------
 # REST API auth (optional). When GARDEN_API_KEY is set, non-localhost


### PR DESCRIPTION
Six commits fixing the built-in web UI when `GARDEN_API_KEY` is set, plus timelapse usability. Found and verified on a real Gardyn Home (Pi Zero 2, two USB cameras).

### The UI silently failed whenever an API key was configured
`/health` is exempt from auth, so the connection dot stayed **green** while every sensor call returned 401 and each tile sat at a dash — the page looked connected and simply had no data. The key field was hidden behind the settings gear with nothing pointing at it. `get()`/`post()` now trap 401, open settings, focus the field and show a banner.

### Sliders reported values the hardware never had
Neither range input carried a `value` attribute, so the browser parked both at the **midpoint of min/max** on load, and the percent labels were hardcoded HTML (`50%`, `100%`). `syncToggles()` fetched the real values but spent them only on the on/off chip. Observed live: UI showed 50% brightness / 100% pump speed while both were actually **0**. Because `onchange` only fires on a real change, a slider parked at a wrong value also made a corrective drag a no-op.

### Camera images could never load with auth on
`<img src>` and `<video src>` are browser-issued requests that **cannot carry the `X-API-Key` header**, so every still and timelapse 401'd. Now fetched in JS with the header and handed to the element as a blob URL, with object URLs revoked before replacement so the live-refresh loop doesn't leak one blob per frame.

### Concurrent captures contend badly on a Pi Zero
Measured on hardware:

| | Upper | Lower |
|---|---|---|
| Both at once | 16.8s | **20.0s** |
| Sequential | 3.1s | 2.5s |

The parallel pair blew the fetch timeout so neither image appeared. Now sequential behind a busy flag, so a live interval shorter than one cycle skips a tick instead of stacking passes. Captions also carry a capture timestamp — a stationary tower looks identical frame to frame, so live mode was indistinguishable from a dead one.

### Timelapse
`TIMELAPSE_MAX_FRAMES` is a cap, not a minimum, but a fresh archive built at a fixed 12fps produced a clip under a second. `framerate_for()` stretches short archives toward `TIMELAPSE_TARGET_SECONDS` (clamped `1..TIMELAPSE_FPS`) — 8 frames now build an 8s clip instead of 0.7s, verified with `ffprobe`. New `GET /camera/timelapse/<cam>/status` reports frame count, first/last capture times and an advisory `TIMELAPSE_MIN_FRAMES`, rendered under each player instead of leaving it blank.

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **126 tests, OK**; `ruff check .` and `black --check .` clean. Every change exercised against live hardware; new config is env-overridable and documented in `.env-dist`.


---

### Related issues
Contributes to **#31** (camera API endpoints) — adds `GET /camera/timelapse/<cam>/status` reporting frame count, first/last capture times and the advisory minimum, and fixes camera/timelapse retrieval when `GARDEN_API_KEY` is set.
