### PR TITLE
fix(web): round pump power stats to two decimals

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -456,6 +456,11 @@
     async function setPump(on) { await post(on ? "/pump/on" : "/pump/off"); setActive("pump", on); }
     async function runPump() { const s = +$("run-secs").value; await post("/pump/run", { seconds: s }); setActive("pump", true); }
 
+    // INA219 readings arrive at full float precision (0.24390243902439024 mA),
+    // which overflows the tile it is rendered into. Two decimals is already well
+    // past what the sensor resolves.
+    const fmtStat = v => (v == null || !isFinite(+v)) ? "\u2014" : (+v).toFixed(2);
+
     async function refresh() {
       const sensors = {
         "/temperature": ["s-temp", "temperature"],
@@ -482,7 +487,12 @@
       } catch { $("s-water").textContent = "n/a"; $("s-water-gal").textContent = "n/a"; $("s-water-status").textContent = ""; }
       try {
         const p = await get("/pump/stats");
-        if (p.BusVoltage != null) { $("p-volt").textContent = p.BusVoltage; $("p-curr").textContent = p.BusCurrent; $("p-pow").textContent = p.Power; $("p-shunt").textContent = p.ShuntVoltage ?? "—"; }
+        if (p.BusVoltage != null) {
+          $("p-volt").textContent = fmtStat(p.BusVoltage);
+          $("p-curr").textContent = fmtStat(p.BusCurrent);
+          $("p-pow").textContent = fmtStat(p.Power);
+          $("p-shunt").textContent = fmtStat(p.ShuntVoltage);
+        }
         else { $("p-volt").textContent = $("p-curr").textContent = $("p-pow").textContent = $("p-shunt").textContent = "—"; }
       } catch { /* optional */ }
       $("updated").textContent = "updated " + new Date().toLocaleTimeString();


### PR DESCRIPTION
Single-commit fix, independent of #96/#97/#98.

### Problem
`GET /pump/stats` returns raw INA219 floats and the web UI renders them verbatim into fixed-width tiles. Live values from a Gardyn Home:

```json
{"BusCurrent":0.24390243902439024,"BusVoltage":12.164,
 "Power":3.048780487804878,"ShuntVoltage":0.03}
```

`0.24390243902439024` overflows its card and spills across the layout — the Current and Power tiles are unreadable in the built-in UI.

### Fix
A shared `fmtStat()` helper renders each of the four pump readings at two decimals, which is already past what the INA219 resolves:

| Field | Before | After |
|---|---|---|
| BusCurrent | `0.24390243902439024` | `0.24` |
| BusVoltage | `12.164` | `12.16` |
| Power | `3.048780487804878` | `3.05` |
| ShuntVoltage | `0.03` | `0.03` |

It also folds in the null handling that previously only the shunt reading had (`?? "—"`), so any missing field renders an em-dash rather than `undefined`. Verified against `null`, `undefined` and `NaN`.

Display-only — the API response is untouched, so anything consuming `/pump/stats` still gets full precision.

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **126 tests, OK**; `ruff check .` and `black --check .` clean. `node --check` on the extracted UI script passes. Confirmed against live hardware readings.


---

### Related issues
Minor display fix to the pump power readout surfaced by the built-in web UI; no dedicated issue.
