### PR TITLE
fix(hardware): stop driver construction from resetting the pins

### DIFF
--- a/app/lib/hardware.py
+++ b/app/lib/hardware.py
@@ -53,6 +53,35 @@ def get_pin_factory():
     return _pin_factory
 
 
+def current_duty_fraction(pi, pin, default=0):
+    """Read ``pin``'s live PWM duty cycle from pigpiod as a 0..1 fraction.
+
+    ``PWMLED(pin)`` defaults to ``initial_value=0``, so merely constructing a
+    driver writes zero to the pin. Because the route modules instantiate their
+    drivers at import, every start of the REST API used to switch the lights and
+    pump off -- silently undoing whatever the cron schedule had set. Passing this
+    value as ``initial_value`` makes construction observe the pin instead of
+    resetting it. ``initial_value=None`` is not usable here: gpiozero's PWMLED
+    range-checks it and raises TypeError.
+
+    Returns ``default`` when the pin is not in PWM mode or pigpio is unavailable,
+    which is also the off-Pi path.
+    """
+    if pi is None:
+        return default
+    try:
+        duty = pi.get_PWM_dutycycle(pin)
+        span = pi.get_PWM_range(pin)
+    except Exception as exc:  # noqa: BLE001 - any pigpio error means "unknown"
+        logger.debug("Could not read PWM duty for pin %s: %s", pin, exc)
+        return default
+    try:
+        fraction = float(duty) / float(span)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+    return min(1.0, max(0.0, fraction))
+
+
 def i2c_device_present(address):
     """Return True if an I2C device ACKs at ``address`` on bus 1."""
     try:

--- a/app/sensors/light/light.py
+++ b/app/sensors/light/light.py
@@ -7,6 +7,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -36,8 +37,13 @@ class Light:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.led = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # Open the pigpio client first so the pin's live duty cycle can be read
+        # and handed to PWMLED as its initial value. Without that, constructing
+        # this driver writes 0 and switches the light off -- which happened on
+        # every start of the REST API, undoing the cron schedule.
         self.gpio = GPIOController(pin, pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.led = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/pump/pump.py
+++ b/app/sensors/pump/pump.py
@@ -5,6 +5,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -34,8 +35,11 @@ class Pump:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # See Light.__init__: read the live duty cycle before constructing PWMLED
+        # so instantiating this driver cannot cut a scheduled pump run short.
         self.gpio = GPIOController(pin, self.pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -44,5 +44,46 @@ class SystemRouteTestCase(unittest.TestCase):
         self.assertEqual(body["profile"], config.MODELS["gardyn 3.0"])
 
 
+class CurrentDutyFractionTestCase(unittest.TestCase):
+    """Constructing a driver must observe the pin, not reset it.
+
+    PWMLED defaults to initial_value=0, so before this helper existed every
+    start of the REST API wrote 0 to the light and pump pins and undid whatever
+    the cron schedule had set.
+    """
+
+    class _Pi:
+        def __init__(self, duty, span):
+            self._duty, self._span = duty, span
+
+        def get_PWM_dutycycle(self, _pin):
+            if isinstance(self._duty, Exception):
+                raise self._duty
+            return self._duty
+
+        def get_PWM_range(self, _pin):
+            return self._span
+
+    def test_reads_live_duty_as_a_fraction(self):
+        self.assertAlmostEqual(hardware.current_duty_fraction(self._Pi(6500, 10000), 18), 0.65)
+
+    def test_off_pin_reads_zero(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(0, 10000), 18), 0)
+
+    def test_no_pigpio_client_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(None, 18), 0)
+        self.assertEqual(hardware.current_duty_fraction(None, 18, default=1), 1)
+
+    def test_pin_not_in_pwm_mode_falls_back(self):
+        pi = self._Pi(Exception("GPIO not set up for PWM"), 10000)
+        self.assertEqual(hardware.current_duty_fraction(pi, 18), 0)
+
+    def test_zero_range_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(100, 0), 18), 0)
+
+    def test_result_is_clamped(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(20000, 10000), 18), 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Found on a live Gardyn Home while diagnosing why a working cron schedule appeared to do nothing. Independent of #96–#99.

### The bug
`PWMLED` defaults to `initial_value=0`, so *constructing* a driver writes zero to its pin:

```python
self.led = PWMLED(self.pin, pin_factory=self.pin_factory)   # writes 0
```

`app/__init__.py` imports every sensor blueprint at module level, and each `routes.py` instantiates its driver at import. So **every start of the REST API switches the lights and pump off**, silently undoing whatever the cron schedule set.

On a live tower that means a restart mid-photoperiod kills the lights until the next scheduled on-time, and a restart during a pump run cuts the run short. It is invisible in the logs — nothing errors, the schedule is intact, cron fires correctly, and the hardware just goes dark.

### Reproduction (hardware)
```
light at 65%                        -> pigs gdc 18 = 6500
sudo systemctl restart garden-api   -> pigs gdc 18 = 0
```

### The fix
`hardware.current_duty_fraction()` reads the pin's live duty cycle from pigpiod, and both drivers pass it as `initial_value` — so construction observes the pin instead of resetting it.

`initial_value=None` is **not** usable here; gpiozero's PWMLED range-checks the argument:
```
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

It falls back to `0` when the pin is not in PWM mode or pigpio is unavailable — which is also the off-Pi path, so the stubbed suite is unaffected.

### Verified on hardware, after the fix
| Scenario | Result |
|---|---|
| Light at 65%, restart API | stays `6500` |
| Pump mid-run, restart API | stays `5000`, then stops on schedule |

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **144 tests, OK** (adds 6 covering the fraction maths, a non-PWM pin, a missing pigpio client, zero range, and clamping); `ruff check .` and `black --check .` clean.


---

### Related issues
Addresses **#3** (power loss recovery — *"system has to be cycled a few times after a power loss"*).

This is one of the two mechanisms behind that symptom: because constructing a driver wrote 0 to its pin, any service start or restart switched the actuators off. Cycling the system repeatedly is exactly what you would do to work around it. #101 covers the other half — the persisted state the recovery path reads was never updated by cron.
