### PR TITLE
fix(mqtt): track actuator changes made outside the service

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -52,6 +52,7 @@ OVER_TEMP_HYSTERESIS=34
 WATER_LOW_CM=11
 # How often (s) to re-read the tank and refresh the low-water alert.
 WATER_CHECK_SECONDS=180
+ACTUATOR_POLL_SECONDS=15
 # Tank geometry for the gallons readout: sensor->surface distance (cm) when full
 # vs empty, and capacity in gallons (Home ~5, Studio ~4). Calibrate to your unit.
 WATER_FULL_CM=5

--- a/app/lib/hardware.py
+++ b/app/lib/hardware.py
@@ -53,6 +53,35 @@ def get_pin_factory():
     return _pin_factory
 
 
+def current_duty_fraction(pi, pin, default=0):
+    """Read ``pin``'s live PWM duty cycle from pigpiod as a 0..1 fraction.
+
+    ``PWMLED(pin)`` defaults to ``initial_value=0``, so merely constructing a
+    driver writes zero to the pin. Because the route modules instantiate their
+    drivers at import, every start of the REST API used to switch the lights and
+    pump off -- silently undoing whatever the cron schedule had set. Passing this
+    value as ``initial_value`` makes construction observe the pin instead of
+    resetting it. ``initial_value=None`` is not usable here: gpiozero's PWMLED
+    range-checks it and raises TypeError.
+
+    Returns ``default`` when the pin is not in PWM mode or pigpio is unavailable,
+    which is also the off-Pi path.
+    """
+    if pi is None:
+        return default
+    try:
+        duty = pi.get_PWM_dutycycle(pin)
+        span = pi.get_PWM_range(pin)
+    except Exception as exc:  # noqa: BLE001 - any pigpio error means "unknown"
+        logger.debug("Could not read PWM duty for pin %s: %s", pin, exc)
+        return default
+    try:
+        fraction = float(duty) / float(span)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+    return min(1.0, max(0.0, fraction))
+
+
 def i2c_device_present(address):
     """Return True if an I2C device ACKs at ``address`` on bus 1."""
     try:

--- a/app/sensors/light/light.py
+++ b/app/sensors/light/light.py
@@ -7,6 +7,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -36,8 +37,13 @@ class Light:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.led = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # Open the pigpio client first so the pin's live duty cycle can be read
+        # and handed to PWMLED as its initial value. Without that, constructing
+        # this driver writes 0 and switches the light off -- which happened on
+        # every start of the REST API, undoing the cron schedule.
         self.gpio = GPIOController(pin, pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.led = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/pump/pump.py
+++ b/app/sensors/pump/pump.py
@@ -5,6 +5,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -34,8 +35,11 @@ class Pump:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # See Light.__init__: read the live duty cycle before constructing PWMLED
+        # so instantiating this driver cannot cut a scheduled pump run short.
         self.gpio = GPIOController(pin, self.pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -230,6 +230,84 @@ def _write_crontab(lines):
     subprocess.run(["crontab", "-"], input=payload, text=True, check=True)
 
 
+def _effective_days(schedule, kind, now):
+    """The day map in force for ``kind`` ("lights"/"pump"), honouring Vacation
+    mode, or None when that half of the schedule is switched off."""
+    if is_vacation_active(schedule, today=now.date()):
+        return {day: list(VACATION_PROFILE[kind]) for day in DAYS}
+    section = schedule.get(kind) or {}
+    if not section.get("enabled"):
+        return None
+    return section.get("days") or _empty_days()
+
+
+def expected_light_state(schedule, now=None, lookback_days=8):
+    """What the compiled schedule has the light doing at ``now``.
+
+    Returns ``(on, brightness)``, or ``None`` when the schedule expresses no
+    opinion (lights disabled, or no windows at all) so callers leave the pin be.
+
+    This deliberately replays the crontab's own semantics -- the most recent
+    on/off event at or before ``now`` wins -- rather than interpreting each
+    window as an interval. Windows that run past midnight, several windows in
+    one day, and deliberate gaps then all agree with what cron actually did.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "lights", now)
+    if days is None:
+        return None
+
+    latest = None
+    for delta in range(lookback_days):
+        date = (now - datetime.timedelta(days=delta)).date()
+        for window in days.get(DAYS[date.weekday()], []):
+            brightness = int(window.get("brightness", 70))
+            try:
+                on_m, on_h = _hh_mm(window.get("onTime", "08:00"))
+                off_m, off_h = _hh_mm(window.get("offTime", "22:00"))
+            except (ValueError, AttributeError):
+                continue
+            for stamp, on, level in (
+                (datetime.datetime.combine(date, datetime.time(on_h, on_m)), True, brightness),
+                (datetime.datetime.combine(date, datetime.time(off_h, off_m)), False, 0),
+            ):
+                if stamp <= now and (latest is None or stamp > latest[0]):
+                    latest = (stamp, on, level)
+
+    if latest is None:
+        return None
+    return latest[1], latest[2]
+
+
+def expected_pump_run(schedule, now=None):
+    """Seconds still owed to a pump run that should be under way at ``now``.
+
+    Returns ``None`` when no run is in progress. Reported rather than acted on
+    automatically: a service that crash-loops would otherwise restart the pump
+    on every boot, and a missed run self-heals at the next scheduled one.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "pump", now)
+    if days is None:
+        return None
+
+    for delta in (0, 1):  # today, and yesterday for a run spanning midnight
+        date = (now - datetime.timedelta(days=delta)).date()
+        for run in days.get(DAYS[date.weekday()], []):
+            try:
+                run_m, run_h = _hh_mm(run.get("time", "12:00"))
+                seconds = _pump_seconds(run.get("duration", 5))
+            except (ValueError, AttributeError, TypeError):
+                continue
+            start = datetime.datetime.combine(date, datetime.time(run_h, run_m))
+            remaining = (start + datetime.timedelta(seconds=seconds) - now).total_seconds()
+            if 0 < remaining <= seconds:
+                return int(remaining)
+    return None
+
+
 def apply_schedule(schedule):
     """Persist the schedule and replace our crontab entries with its compiled form."""
     # Validate/compile first so a bad schedule never touches crontab.

--- a/config.py
+++ b/config.py
@@ -122,6 +122,12 @@ WATER_LOW_CM = _get_float("WATER_LOW_CM", 0) or None
 # low-water alert. Kept short so a transient false alarm self-clears quickly.
 WATER_CHECK_SECONDS = _get_int("WATER_CHECK_SECONDS", 180)
 
+# How often (seconds) the MQTT service re-reads the light/pump duty cycles and
+# republishes them. cron, the REST API, the CLI and the physical button all drive
+# the hardware without going through the MQTT service, so without polling Home
+# Assistant drifts out of step with reality. 0 disables the poll.
+ACTUATOR_POLL_SECONDS = _get_int("ACTUATOR_POLL_SECONDS", 15)
+
 # Tank geometry for the cm->gallons readout: distance (cm) from the sensor to the
 # water surface when the tank is full vs empty, and the tank capacity in gallons
 # (Gardyn Home ~5 gal, Studio ~4 gal). Calibrate FULL/EMPTY to your unit.

--- a/mqtt.py
+++ b/mqtt.py
@@ -16,7 +16,7 @@ from gpiozero import Button  # Import gpiozero Button
 
 from app.lib import grow as grow_lib
 from app.lib import state as state_lib
-from app.lib.hardware import detect_model, get_pin_factory
+from app.lib.hardware import current_duty_fraction, detect_model, get_pin_factory
 from app.lib.logging_config import configure_logging
 from app.lib.water import is_water_low
 from app.sensors.camera import camera as camera_mod
@@ -29,6 +29,7 @@ from app.sensors.pump.routes import pump_control
 from app.sensors.schedule import schedule as sched_lib
 from app.sensors.temperature.temperature import temperature_sensor
 from config import (
+    ACTUATOR_POLL_SECONDS,
     BASE_TOPIC,
     BROKER,
     BUTTON_PIN,
@@ -1104,6 +1105,127 @@ def restore_actuator_state(client):
         logger.error("Failed to restore actuator state: %s", exc)
 
 
+def reconcile_actuator_state(client):
+    """Republish the actuators' real duty cycles on a timer.
+
+    cron, the REST API, the CLI and the physical button all drive the hardware
+    without passing through this service, so a service that only publishes what
+    it commanded drifts: Home Assistant showed the light OFF while it was on at
+    65%, and the pump OFF through a scheduled run. gpiozero reads PWM duty back
+    through pigpiod, so polling reports the truth whoever made the change.
+
+    The duty cycles are read straight from pigpiod (silently) and only a change
+    triggers a publish, so this neither spams the broker nor the log. It also
+    refreshes the persisted actuator state, which the cron path never touches --
+    that stale file is why power-loss recovery could not restore a scheduled
+    light.
+    """
+    global light_state, pump_state, brightness, speed
+    interval = ACTUATOR_POLL_SECONDS
+    if not interval:
+        logger.info("Actuator polling disabled (ACTUATOR_POLL_SECONDS=0)")
+        return
+
+    last = None
+    while True:
+        try:
+            light_pct = _live_duty_percent(light)
+            pump_pct = _live_duty_percent(pump)
+            snapshot = (light_pct, pump_pct)
+            if None not in snapshot and snapshot != last:
+                # Published straight from the polled percentages rather than via a
+                # helper that re-reads the pins, so this needs nothing beyond the
+                # topics the light/pump discovery already declares.
+                client.publish(
+                    BASE_TOPIC + "/light/state", "ON" if light_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/light/brightness/state", str(light_pct), retain=True)
+                client.publish(
+                    BASE_TOPIC + "/pump/state", "ON" if pump_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/pump/speed/state", str(pump_pct), retain=True)
+                logger.info(
+                    "Actuator state: light %s at %s%%, pump %s at %s%%",
+                    "ON" if light_pct > 0 else "OFF",
+                    light_pct,
+                    "ON" if pump_pct > 0 else "OFF",
+                    pump_pct,
+                )
+                light_state = light_pct > 0
+                pump_state = pump_pct > 0
+                if light_pct > 0:
+                    brightness = light_pct
+                if pump_pct > 0:
+                    speed = pump_pct
+                state_lib.save_state(
+                    light_on=light_state,
+                    brightness=brightness,
+                    pump_on=pump_state,
+                    speed=speed,
+                )
+                last = snapshot
+        except Exception:
+            logger.exception("Error reconciling actuator state")
+        sleep(interval)
+
+
+def _live_duty_percent(driver):
+    """A driver's current duty cycle as a whole percent, read from pigpiod.
+
+    Deliberately silent -- the drivers' own getters log on every call, which at
+    poll frequency would bury the log. Returns None when it cannot be read.
+    """
+    fraction = current_duty_fraction(getattr(driver.gpio, "pi", None), driver.pin, default=None)
+    return None if fraction is None else int(round(fraction * 100))
+
+
+def apply_scheduled_state(client):
+    """Bring the light in line with what the schedule says should be on now.
+
+    Cron drives the actuators through the ``light``/``water`` CLIs, which never
+    touch the persisted actuator state, so ``restore_actuator_state`` can only
+    ever recover a state some MQTT/HA action last wrote. After a power cut in the
+    middle of a photoperiod that leaves the tower dark until the next scheduled
+    on-time -- up to a full day. Replaying the schedule's current expectation on
+    startup closes that gap, and runs after the saved-state restore so the
+    schedule wins over a stale value.
+
+    The pump is reported but deliberately not started: this runs on every
+    connect, and a service that crash-loops would otherwise re-trigger watering
+    each time, whereas a missed run self-heals at the next scheduled one.
+    """
+    global light_state, brightness
+    try:
+        schedule = sched_lib.load_schedule()
+        expected = sched_lib.expected_light_state(schedule)
+        if expected is None:
+            logger.info("Schedule has no light opinion; leaving the light as-is")
+        else:
+            should_be_on, level = expected
+            if should_be_on:
+                light_state = True
+                brightness = level
+                light.set_duty_cycle(level)
+                client.publish(BASE_TOPIC + "/light/state", "ON")
+                client.publish(BASE_TOPIC + "/light/brightness", str(level))
+            else:
+                light_state = False
+                light.off()
+                client.publish(BASE_TOPIC + "/light/state", "OFF")
+            state_lib.save_state(light_on=light_state, brightness=brightness)
+            logger.info("Applied scheduled light state: on=%s brightness=%s", should_be_on, level)
+
+        owed = sched_lib.expected_pump_run(schedule)
+        if owed:
+            logger.warning(
+                "A scheduled pump run has %ss left; not auto-starting it. "
+                "Next scheduled run will proceed normally.",
+                owed,
+            )
+    except Exception:
+        logger.exception("Error applying scheduled state")
+
+
 def publish_grow_reminders(client):
     """Publish grow stage and any due reminders (thinning/root/harvest/nutrient)."""
     while True:
@@ -1182,10 +1304,17 @@ if __name__ == "__main__":
     grow_thread.daemon = True
     grow_thread.start()
 
-    # Restore last known actuator state after (re)connect.
+    actuator_thread = threading.Thread(target=reconcile_actuator_state, args=(client,))
+    actuator_thread.daemon = True
+    actuator_thread.start()
+
+    # Restore last known actuator state after (re)connect, then let the schedule
+    # override it -- cron-driven changes never reach the persisted state, so the
+    # schedule is the more trustworthy source for what should be on right now.
     client.on_connect = lambda c, u, f, rc, properties=None: (
         on_connect(c, u, f, rc, properties),
         restore_actuator_state(c),
+        apply_scheduled_state(c),
     )
 
     client.loop_forever()

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -44,5 +44,46 @@ class SystemRouteTestCase(unittest.TestCase):
         self.assertEqual(body["profile"], config.MODELS["gardyn 3.0"])
 
 
+class CurrentDutyFractionTestCase(unittest.TestCase):
+    """Constructing a driver must observe the pin, not reset it.
+
+    PWMLED defaults to initial_value=0, so before this helper existed every
+    start of the REST API wrote 0 to the light and pump pins and undid whatever
+    the cron schedule had set.
+    """
+
+    class _Pi:
+        def __init__(self, duty, span):
+            self._duty, self._span = duty, span
+
+        def get_PWM_dutycycle(self, _pin):
+            if isinstance(self._duty, Exception):
+                raise self._duty
+            return self._duty
+
+        def get_PWM_range(self, _pin):
+            return self._span
+
+    def test_reads_live_duty_as_a_fraction(self):
+        self.assertAlmostEqual(hardware.current_duty_fraction(self._Pi(6500, 10000), 18), 0.65)
+
+    def test_off_pin_reads_zero(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(0, 10000), 18), 0)
+
+    def test_no_pigpio_client_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(None, 18), 0)
+        self.assertEqual(hardware.current_duty_fraction(None, 18, default=1), 1)
+
+    def test_pin_not_in_pwm_mode_falls_back(self):
+        pi = self._Pi(Exception("GPIO not set up for PWM"), 10000)
+        self.assertEqual(hardware.current_duty_fraction(pi, 18), 0)
+
+    def test_zero_range_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(100, 0), 18), 0)
+
+    def test_result_is_clamped(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(20000, 10000), 18), 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -146,3 +146,75 @@ class NormalizeScheduleTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExpectedStateTestCase(unittest.TestCase):
+    """What the schedule says should be running right now.
+
+    Used on startup to recover from a power cut mid-photoperiod: cron drives the
+    actuators through the CLIs, which never update the persisted actuator state,
+    so without this the tower stays dark until the next scheduled on-time.
+    """
+
+    # 2026-08-31 is a Monday.
+    def _at(self, hour, minute=0, day=31):
+        return datetime.datetime(2026, 8, day, hour, minute)
+
+    def _daily(self, windows=None, runs=None, lights=True, pump=True):
+        return {
+            "lights": {"enabled": lights, "days": {d: list(windows or []) for d in sched.DAYS}},
+            "pump": {"enabled": pump, "days": {d: list(runs or []) for d in sched.DAYS}},
+        }
+
+    def test_inside_window_is_on_at_that_brightness(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (True, 65))
+
+    def test_after_off_time_is_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(22)), (False, 0))
+
+    def test_before_first_on_time_uses_yesterdays_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(3)), (False, 0))
+
+    def test_window_spanning_midnight_follows_cron_semantics(self):
+        # Compiled as "on 23:00" and "off 07:00" on the same weekday, so at 02:00
+        # the most recent event is the previous day's 23:00 on.
+        s = self._daily([{"onTime": "23:00", "offTime": "07:00", "brightness": 80}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(2)), (True, 80))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(8)), (False, 0))
+
+    def test_latest_of_several_windows_wins(self):
+        s = self._daily(
+            [
+                {"onTime": "05:00", "offTime": "09:00", "brightness": 40},
+                {"onTime": "17:00", "offTime": "21:00", "brightness": 90},
+            ]
+        )
+        self.assertEqual(sched.expected_light_state(s, now=self._at(18)), (True, 90))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (False, 0))
+
+    def test_disabled_or_empty_expresses_no_opinion(self):
+        self.assertIsNone(sched.expected_light_state(self._daily(lights=False), now=self._at(9)))
+        self.assertIsNone(sched.expected_light_state(self._daily([]), now=self._at(9)))
+
+    def test_vacation_profile_overrides(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        s["vacation"] = {"enabled": True, "until": None}
+        # Vacation keeps lights 10:00-16:00 at 50%.
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (True, 50))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (False, 0))
+
+    def test_pump_run_in_progress_reports_remaining_seconds(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertEqual(sched.expected_pump_run(s, now=self._at(9, 1)), 120)
+
+    def test_pump_run_outside_window_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 5)))
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(8, 59)))
+
+    def test_pump_disabled_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}], pump=False)
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 1)))


### PR DESCRIPTION
Found on a live Gardyn Home. Builds on #100 (which stops driver construction resetting the pins); independent of #96–#99.

### The gap
cron drives the light and pump through the `light`/`water` CLIs, and the REST API and physical button drive them directly. **Nothing outside the MQTT service ever reached its published state**, because the service only publishes what it itself commanded. Two consequences on real hardware:

**1. Home Assistant drifts out of step with reality.** It showed the light OFF while it was on at 65%, and OFF through an entire scheduled pump run.

**2. Power-loss recovery cannot restore a scheduled light.** `restore_actuator_state` reads a persisted file the cron path never updates, so after a power cut mid-photoperiod the tower stays dark until the next scheduled on-time — up to a full day.

### Fix 1 — poll the hardware
`reconcile_actuator_state()` reads both duty cycles every `ACTUATOR_POLL_SECONDS` (default 15) and republishes on change.

gpiozero reads PWM duty back through pigpiod, verified on hardware — an external `light 30` was observed in-process as `30.0`, matching `pigs gdc 18` = 3000 — so polling reports the truth whoever made the change. Duty is read straight from pigpiod so the poll itself is silent, and only a change publishes, keeping both the broker and the log quiet. It also refreshes the persisted state, closing the recovery gap above.

Observed live, changing the light externally via the CLI:
```
09:09:40  Light is ON at 65%     <- schedule applied on connect
09:10:25  Light is ON at 40%     <- external CLI change picked up
~/.garden_state.json -> {"light_on": true, "brightness": 40, ...}   (was stale at false)
```

### Fix 2 — replay the schedule on connect
`apply_scheduled_state()` applies what the schedule says should be active, after the saved-state restore so the schedule wins over a stale value.

`expected_light_state()` deliberately replays the **crontab's own semantics** — the most recent on/off event at or before `now` wins — rather than treating each window as an interval. Windows spanning midnight, several windows per day, and deliberate gaps then all agree with what cron actually did. Vacation mode is honoured.

Verified end to end: light forced off to simulate a post-power-cut dark state, `systemctl restart mqtt.service`, light returned to its scheduled 65%.

The pump is reported but **never auto-started** — this runs on every connect, and a service that crash-loops would re-trigger watering each time, whereas a missed run self-heals at the next of seven daily runs. `expected_pump_run()` returns the seconds owed so it can be logged.

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **154 tests, OK** (adds 10 covering inside/outside a window, the midnight-spanning case, multiple windows, disabled/empty expressing no opinion, the vacation override, and pump-run remainder maths); `ruff check .` and `black --check .` clean. New setting documented in `.env-dist`; `0` disables the poll.

---

**Stacks on #100.** The poll needs to read a pin's live duty cycle, which #100 introduces, so this branch is based on it and its commit appears here too. Merge #100 first.

*(Amended after opening: the first push called `publish_light_state`/`publish_pump_state`, which turned out to be fork-only helpers not present on `main` — I had validated on a branch that had them. It now publishes straight from the polled percentages, needing nothing beyond the topics light/pump discovery already declares. 142 tests OK standalone on this base.)*

---

### Related issues
Addresses **#3** (power loss recovery), together with #100.

`restore_actuator_state` reads a persisted file that only MQTT-initiated changes ever wrote, so anything cron/CLI/button-driven was invisible to it — after a power cut mid-photoperiod the tower stayed dark until the next scheduled on-time. The poll keeps that file truthful, and `apply_scheduled_state()` replays the schedule's current expectation on connect so recovery no longer depends on the file being right.


Also adjacent to **#32** (schedule API endpoints): adds `expected_light_state()` and `expected_pump_run()` to the schedule library, surfaced here over MQTT only — **no REST endpoint is added**. See the gap notes on #32.
