### PR TITLE
feat(mqtt): expose the next scheduled pump run to Home Assistant

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -52,6 +52,7 @@ OVER_TEMP_HYSTERESIS=34
 WATER_LOW_CM=11
 # How often (s) to re-read the tank and refresh the low-water alert.
 WATER_CHECK_SECONDS=180
+ACTUATOR_POLL_SECONDS=15
 # Tank geometry for the gallons readout: sensor->surface distance (cm) when full
 # vs empty, and capacity in gallons (Home ~5, Studio ~4). Calibrate to your unit.
 WATER_FULL_CM=5

--- a/app/lib/hardware.py
+++ b/app/lib/hardware.py
@@ -53,6 +53,35 @@ def get_pin_factory():
     return _pin_factory
 
 
+def current_duty_fraction(pi, pin, default=0):
+    """Read ``pin``'s live PWM duty cycle from pigpiod as a 0..1 fraction.
+
+    ``PWMLED(pin)`` defaults to ``initial_value=0``, so merely constructing a
+    driver writes zero to the pin. Because the route modules instantiate their
+    drivers at import, every start of the REST API used to switch the lights and
+    pump off -- silently undoing whatever the cron schedule had set. Passing this
+    value as ``initial_value`` makes construction observe the pin instead of
+    resetting it. ``initial_value=None`` is not usable here: gpiozero's PWMLED
+    range-checks it and raises TypeError.
+
+    Returns ``default`` when the pin is not in PWM mode or pigpio is unavailable,
+    which is also the off-Pi path.
+    """
+    if pi is None:
+        return default
+    try:
+        duty = pi.get_PWM_dutycycle(pin)
+        span = pi.get_PWM_range(pin)
+    except Exception as exc:  # noqa: BLE001 - any pigpio error means "unknown"
+        logger.debug("Could not read PWM duty for pin %s: %s", pin, exc)
+        return default
+    try:
+        fraction = float(duty) / float(span)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+    return min(1.0, max(0.0, fraction))
+
+
 def i2c_device_present(address):
     """Return True if an I2C device ACKs at ``address`` on bus 1."""
     try:

--- a/app/sensors/light/light.py
+++ b/app/sensors/light/light.py
@@ -7,6 +7,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -36,8 +37,13 @@ class Light:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.led = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # Open the pigpio client first so the pin's live duty cycle can be read
+        # and handed to PWMLED as its initial value. Without that, constructing
+        # this driver writes 0 and switches the light off -- which happened on
+        # every start of the REST API, undoing the cron schedule.
         self.gpio = GPIOController(pin, pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.led = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/pump/pump.py
+++ b/app/sensors/pump/pump.py
@@ -5,6 +5,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -34,8 +35,11 @@ class Pump:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # See Light.__init__: read the live duty cycle before constructing PWMLED
+        # so instantiating this driver cannot cut a scheduled pump run short.
         self.gpio = GPIOController(pin, self.pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -308,6 +308,36 @@ def expected_pump_run(schedule, now=None):
     return None
 
 
+def next_pump_run(schedule, now=None, lookahead_days=8):
+    """When the next scheduled pump run starts, as a naive local datetime.
+
+    Returns None when the pump schedule is disabled or has no runs. This exists
+    because the writable "Pump Run Time" entity can only express a single run per
+    day: on a multi-cycle schedule it shows the first run and never moves, so a
+    dashboard reading it appears frozen.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "pump", now)
+    if days is None:
+        return None
+
+    for delta in range(lookahead_days):
+        date = (now + datetime.timedelta(days=delta)).date()
+        soonest = None
+        for run in days.get(DAYS[date.weekday()], []):
+            try:
+                run_m, run_h = _hh_mm(run.get("time", "12:00"))
+            except (ValueError, AttributeError):
+                continue
+            start = datetime.datetime.combine(date, datetime.time(run_h, run_m))
+            if start > now and (soonest is None or start < soonest):
+                soonest = start
+        if soonest is not None:
+            return soonest
+    return None
+
+
 def apply_schedule(schedule):
     """Persist the schedule and replace our crontab entries with its compiled form."""
     # Validate/compile first so a bad schedule never touches crontab.

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -230,6 +230,84 @@ def _write_crontab(lines):
     subprocess.run(["crontab", "-"], input=payload, text=True, check=True)
 
 
+def _effective_days(schedule, kind, now):
+    """The day map in force for ``kind`` ("lights"/"pump"), honouring Vacation
+    mode, or None when that half of the schedule is switched off."""
+    if is_vacation_active(schedule, today=now.date()):
+        return {day: list(VACATION_PROFILE[kind]) for day in DAYS}
+    section = schedule.get(kind) or {}
+    if not section.get("enabled"):
+        return None
+    return section.get("days") or _empty_days()
+
+
+def expected_light_state(schedule, now=None, lookback_days=8):
+    """What the compiled schedule has the light doing at ``now``.
+
+    Returns ``(on, brightness)``, or ``None`` when the schedule expresses no
+    opinion (lights disabled, or no windows at all) so callers leave the pin be.
+
+    This deliberately replays the crontab's own semantics -- the most recent
+    on/off event at or before ``now`` wins -- rather than interpreting each
+    window as an interval. Windows that run past midnight, several windows in
+    one day, and deliberate gaps then all agree with what cron actually did.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "lights", now)
+    if days is None:
+        return None
+
+    latest = None
+    for delta in range(lookback_days):
+        date = (now - datetime.timedelta(days=delta)).date()
+        for window in days.get(DAYS[date.weekday()], []):
+            brightness = int(window.get("brightness", 70))
+            try:
+                on_m, on_h = _hh_mm(window.get("onTime", "08:00"))
+                off_m, off_h = _hh_mm(window.get("offTime", "22:00"))
+            except (ValueError, AttributeError):
+                continue
+            for stamp, on, level in (
+                (datetime.datetime.combine(date, datetime.time(on_h, on_m)), True, brightness),
+                (datetime.datetime.combine(date, datetime.time(off_h, off_m)), False, 0),
+            ):
+                if stamp <= now and (latest is None or stamp > latest[0]):
+                    latest = (stamp, on, level)
+
+    if latest is None:
+        return None
+    return latest[1], latest[2]
+
+
+def expected_pump_run(schedule, now=None):
+    """Seconds still owed to a pump run that should be under way at ``now``.
+
+    Returns ``None`` when no run is in progress. Reported rather than acted on
+    automatically: a service that crash-loops would otherwise restart the pump
+    on every boot, and a missed run self-heals at the next scheduled one.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "pump", now)
+    if days is None:
+        return None
+
+    for delta in (0, 1):  # today, and yesterday for a run spanning midnight
+        date = (now - datetime.timedelta(days=delta)).date()
+        for run in days.get(DAYS[date.weekday()], []):
+            try:
+                run_m, run_h = _hh_mm(run.get("time", "12:00"))
+                seconds = _pump_seconds(run.get("duration", 5))
+            except (ValueError, AttributeError, TypeError):
+                continue
+            start = datetime.datetime.combine(date, datetime.time(run_h, run_m))
+            remaining = (start + datetime.timedelta(seconds=seconds) - now).total_seconds()
+            if 0 < remaining <= seconds:
+                return int(remaining)
+    return None
+
+
 def apply_schedule(schedule):
     """Persist the schedule and replace our crontab entries with its compiled form."""
     # Validate/compile first so a bad schedule never touches crontab.

--- a/config.py
+++ b/config.py
@@ -122,6 +122,12 @@ WATER_LOW_CM = _get_float("WATER_LOW_CM", 0) or None
 # low-water alert. Kept short so a transient false alarm self-clears quickly.
 WATER_CHECK_SECONDS = _get_int("WATER_CHECK_SECONDS", 180)
 
+# How often (seconds) the MQTT service re-reads the light/pump duty cycles and
+# republishes them. cron, the REST API, the CLI and the physical button all drive
+# the hardware without going through the MQTT service, so without polling Home
+# Assistant drifts out of step with reality. 0 disables the poll.
+ACTUATOR_POLL_SECONDS = _get_int("ACTUATOR_POLL_SECONDS", 15)
+
 # Tank geometry for the cm->gallons readout: distance (cm) from the sensor to the
 # water surface when the tank is full vs empty, and the tank capacity in gallons
 # (Gardyn Home ~5 gal, Studio ~4 gal). Calibrate FULL/EMPTY to your unit.

--- a/mqtt.py
+++ b/mqtt.py
@@ -16,7 +16,7 @@ from gpiozero import Button  # Import gpiozero Button
 
 from app.lib import grow as grow_lib
 from app.lib import state as state_lib
-from app.lib.hardware import detect_model, get_pin_factory
+from app.lib.hardware import current_duty_fraction, detect_model, get_pin_factory
 from app.lib.logging_config import configure_logging
 from app.lib.water import is_water_low
 from app.sensors.camera import camera as camera_mod
@@ -29,6 +29,7 @@ from app.sensors.pump.routes import pump_control
 from app.sensors.schedule import schedule as sched_lib
 from app.sensors.temperature.temperature import temperature_sensor
 from config import (
+    ACTUATOR_POLL_SECONDS,
     BASE_TOPIC,
     BROKER,
     BUTTON_PIN,
@@ -1104,6 +1105,127 @@ def restore_actuator_state(client):
         logger.error("Failed to restore actuator state: %s", exc)
 
 
+def reconcile_actuator_state(client):
+    """Republish the actuators' real duty cycles on a timer.
+
+    cron, the REST API, the CLI and the physical button all drive the hardware
+    without passing through this service, so a service that only publishes what
+    it commanded drifts: Home Assistant showed the light OFF while it was on at
+    65%, and the pump OFF through a scheduled run. gpiozero reads PWM duty back
+    through pigpiod, so polling reports the truth whoever made the change.
+
+    The duty cycles are read straight from pigpiod (silently) and only a change
+    triggers a publish, so this neither spams the broker nor the log. It also
+    refreshes the persisted actuator state, which the cron path never touches --
+    that stale file is why power-loss recovery could not restore a scheduled
+    light.
+    """
+    global light_state, pump_state, brightness, speed
+    interval = ACTUATOR_POLL_SECONDS
+    if not interval:
+        logger.info("Actuator polling disabled (ACTUATOR_POLL_SECONDS=0)")
+        return
+
+    last = None
+    while True:
+        try:
+            light_pct = _live_duty_percent(light)
+            pump_pct = _live_duty_percent(pump)
+            snapshot = (light_pct, pump_pct)
+            if None not in snapshot and snapshot != last:
+                # Published straight from the polled percentages rather than via a
+                # helper that re-reads the pins, so this needs nothing beyond the
+                # topics the light/pump discovery already declares.
+                client.publish(
+                    BASE_TOPIC + "/light/state", "ON" if light_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/light/brightness/state", str(light_pct), retain=True)
+                client.publish(
+                    BASE_TOPIC + "/pump/state", "ON" if pump_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/pump/speed/state", str(pump_pct), retain=True)
+                logger.info(
+                    "Actuator state: light %s at %s%%, pump %s at %s%%",
+                    "ON" if light_pct > 0 else "OFF",
+                    light_pct,
+                    "ON" if pump_pct > 0 else "OFF",
+                    pump_pct,
+                )
+                light_state = light_pct > 0
+                pump_state = pump_pct > 0
+                if light_pct > 0:
+                    brightness = light_pct
+                if pump_pct > 0:
+                    speed = pump_pct
+                state_lib.save_state(
+                    light_on=light_state,
+                    brightness=brightness,
+                    pump_on=pump_state,
+                    speed=speed,
+                )
+                last = snapshot
+        except Exception:
+            logger.exception("Error reconciling actuator state")
+        sleep(interval)
+
+
+def _live_duty_percent(driver):
+    """A driver's current duty cycle as a whole percent, read from pigpiod.
+
+    Deliberately silent -- the drivers' own getters log on every call, which at
+    poll frequency would bury the log. Returns None when it cannot be read.
+    """
+    fraction = current_duty_fraction(getattr(driver.gpio, "pi", None), driver.pin, default=None)
+    return None if fraction is None else int(round(fraction * 100))
+
+
+def apply_scheduled_state(client):
+    """Bring the light in line with what the schedule says should be on now.
+
+    Cron drives the actuators through the ``light``/``water`` CLIs, which never
+    touch the persisted actuator state, so ``restore_actuator_state`` can only
+    ever recover a state some MQTT/HA action last wrote. After a power cut in the
+    middle of a photoperiod that leaves the tower dark until the next scheduled
+    on-time -- up to a full day. Replaying the schedule's current expectation on
+    startup closes that gap, and runs after the saved-state restore so the
+    schedule wins over a stale value.
+
+    The pump is reported but deliberately not started: this runs on every
+    connect, and a service that crash-loops would otherwise re-trigger watering
+    each time, whereas a missed run self-heals at the next scheduled one.
+    """
+    global light_state, brightness
+    try:
+        schedule = sched_lib.load_schedule()
+        expected = sched_lib.expected_light_state(schedule)
+        if expected is None:
+            logger.info("Schedule has no light opinion; leaving the light as-is")
+        else:
+            should_be_on, level = expected
+            if should_be_on:
+                light_state = True
+                brightness = level
+                light.set_duty_cycle(level)
+                client.publish(BASE_TOPIC + "/light/state", "ON")
+                client.publish(BASE_TOPIC + "/light/brightness", str(level))
+            else:
+                light_state = False
+                light.off()
+                client.publish(BASE_TOPIC + "/light/state", "OFF")
+            state_lib.save_state(light_on=light_state, brightness=brightness)
+            logger.info("Applied scheduled light state: on=%s brightness=%s", should_be_on, level)
+
+        owed = sched_lib.expected_pump_run(schedule)
+        if owed:
+            logger.warning(
+                "A scheduled pump run has %ss left; not auto-starting it. "
+                "Next scheduled run will proceed normally.",
+                owed,
+            )
+    except Exception:
+        logger.exception("Error applying scheduled state")
+
+
 def publish_grow_reminders(client):
     """Publish grow stage and any due reminders (thinning/root/harvest/nutrient)."""
     while True:
@@ -1182,10 +1304,17 @@ if __name__ == "__main__":
     grow_thread.daemon = True
     grow_thread.start()
 
-    # Restore last known actuator state after (re)connect.
+    actuator_thread = threading.Thread(target=reconcile_actuator_state, args=(client,))
+    actuator_thread.daemon = True
+    actuator_thread.start()
+
+    # Restore last known actuator state after (re)connect, then let the schedule
+    # override it -- cron-driven changes never reach the persisted state, so the
+    # schedule is the more trustworthy source for what should be on right now.
     client.on_connect = lambda c, u, f, rc, properties=None: (
         on_connect(c, u, f, rc, properties),
         restore_actuator_state(c),
+        apply_scheduled_state(c),
     )
 
     client.loop_forever()

--- a/mqtt.py
+++ b/mqtt.py
@@ -595,6 +595,20 @@ def send_discovery_messages(client):
             "device": device_info,
         },
     )
+    # Read-only companion to the writable "Pump Run Time" entity, which can only
+    # express one run per day and so sits frozen on the first of a multi-cycle
+    # schedule. device_class timestamp lets HA render it as "in 2 hours".
+    pub(
+        f"homeassistant/sensor/gardyn/{IDENTIFIER}_pump_next_run/config",
+        {
+            "name": "Next Pump Run",
+            "unique_id": IDENTIFIER + "_pump_next_run",
+            "state_topic": BASE_TOPIC + "/schedule/pump/next",
+            "device_class": "timestamp",
+            "icon": "mdi:clock-fast",
+            "device": device_info,
+        },
+    )
     pub(
         f"homeassistant/button/gardyn/{IDENTIFIER}_grow_start/config",
         {
@@ -776,6 +790,24 @@ def publish_schedule_state(client):
         )
     except Exception:
         logger.exception("Error publishing schedule state")
+    publish_next_pump_run(client)
+
+
+def _next_pump_payload():
+    """The next scheduled pump run as ISO 8601 with a UTC offset, which is what
+    Home Assistant's timestamp device_class needs to render a relative time
+    ("in 2 hours"). "unavailable" when the pump schedule is off or empty."""
+    try:
+        upcoming = sched_lib.next_pump_run(sched_lib.load_schedule())
+    except Exception:
+        logger.exception("Error computing the next pump run")
+        return "unavailable"
+    return upcoming.astimezone().isoformat() if upcoming else "unavailable"
+
+
+def publish_next_pump_run(client):
+    """Publish when the next scheduled pump run starts."""
+    client.publish(BASE_TOPIC + "/schedule/pump/next", _next_pump_payload(), retain=True)
 
 
 def _apply_schedule(client, schedule):
@@ -1127,8 +1159,16 @@ def reconcile_actuator_state(client):
         return
 
     last = None
+    last_next_run = None
     while True:
         try:
+            # The next-run sensor has to advance once a run has passed. It changes
+            # only a handful of times a day, so publish it only when it moves.
+            upcoming = _next_pump_payload()
+            if upcoming != last_next_run:
+                client.publish(BASE_TOPIC + "/schedule/pump/next", upcoming, retain=True)
+                last_next_run = upcoming
+
             light_pct = _live_duty_percent(light)
             pump_pct = _live_duty_percent(pump)
             snapshot = (light_pct, pump_pct)

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -44,5 +44,46 @@ class SystemRouteTestCase(unittest.TestCase):
         self.assertEqual(body["profile"], config.MODELS["gardyn 3.0"])
 
 
+class CurrentDutyFractionTestCase(unittest.TestCase):
+    """Constructing a driver must observe the pin, not reset it.
+
+    PWMLED defaults to initial_value=0, so before this helper existed every
+    start of the REST API wrote 0 to the light and pump pins and undid whatever
+    the cron schedule had set.
+    """
+
+    class _Pi:
+        def __init__(self, duty, span):
+            self._duty, self._span = duty, span
+
+        def get_PWM_dutycycle(self, _pin):
+            if isinstance(self._duty, Exception):
+                raise self._duty
+            return self._duty
+
+        def get_PWM_range(self, _pin):
+            return self._span
+
+    def test_reads_live_duty_as_a_fraction(self):
+        self.assertAlmostEqual(hardware.current_duty_fraction(self._Pi(6500, 10000), 18), 0.65)
+
+    def test_off_pin_reads_zero(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(0, 10000), 18), 0)
+
+    def test_no_pigpio_client_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(None, 18), 0)
+        self.assertEqual(hardware.current_duty_fraction(None, 18, default=1), 1)
+
+    def test_pin_not_in_pwm_mode_falls_back(self):
+        pi = self._Pi(Exception("GPIO not set up for PWM"), 10000)
+        self.assertEqual(hardware.current_duty_fraction(pi, 18), 0)
+
+    def test_zero_range_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(100, 0), 18), 0)
+
+    def test_result_is_clamped(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(20000, 10000), 18), 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -146,3 +146,75 @@ class NormalizeScheduleTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExpectedStateTestCase(unittest.TestCase):
+    """What the schedule says should be running right now.
+
+    Used on startup to recover from a power cut mid-photoperiod: cron drives the
+    actuators through the CLIs, which never update the persisted actuator state,
+    so without this the tower stays dark until the next scheduled on-time.
+    """
+
+    # 2026-08-31 is a Monday.
+    def _at(self, hour, minute=0, day=31):
+        return datetime.datetime(2026, 8, day, hour, minute)
+
+    def _daily(self, windows=None, runs=None, lights=True, pump=True):
+        return {
+            "lights": {"enabled": lights, "days": {d: list(windows or []) for d in sched.DAYS}},
+            "pump": {"enabled": pump, "days": {d: list(runs or []) for d in sched.DAYS}},
+        }
+
+    def test_inside_window_is_on_at_that_brightness(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (True, 65))
+
+    def test_after_off_time_is_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(22)), (False, 0))
+
+    def test_before_first_on_time_uses_yesterdays_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(3)), (False, 0))
+
+    def test_window_spanning_midnight_follows_cron_semantics(self):
+        # Compiled as "on 23:00" and "off 07:00" on the same weekday, so at 02:00
+        # the most recent event is the previous day's 23:00 on.
+        s = self._daily([{"onTime": "23:00", "offTime": "07:00", "brightness": 80}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(2)), (True, 80))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(8)), (False, 0))
+
+    def test_latest_of_several_windows_wins(self):
+        s = self._daily(
+            [
+                {"onTime": "05:00", "offTime": "09:00", "brightness": 40},
+                {"onTime": "17:00", "offTime": "21:00", "brightness": 90},
+            ]
+        )
+        self.assertEqual(sched.expected_light_state(s, now=self._at(18)), (True, 90))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (False, 0))
+
+    def test_disabled_or_empty_expresses_no_opinion(self):
+        self.assertIsNone(sched.expected_light_state(self._daily(lights=False), now=self._at(9)))
+        self.assertIsNone(sched.expected_light_state(self._daily([]), now=self._at(9)))
+
+    def test_vacation_profile_overrides(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        s["vacation"] = {"enabled": True, "until": None}
+        # Vacation keeps lights 10:00-16:00 at 50%.
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (True, 50))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (False, 0))
+
+    def test_pump_run_in_progress_reports_remaining_seconds(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertEqual(sched.expected_pump_run(s, now=self._at(9, 1)), 120)
+
+    def test_pump_run_outside_window_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 5)))
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(8, 59)))
+
+    def test_pump_disabled_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}], pump=False)
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 1)))

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -218,3 +218,23 @@ class ExpectedStateTestCase(unittest.TestCase):
     def test_pump_disabled_is_none(self):
         s = self._daily(runs=[{"time": "09:00", "duration": 3}], pump=False)
         self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 1)))
+
+    def test_next_pump_run_skips_runs_already_past(self):
+        runs = [{"time": h, "duration": 3} for h in ("01:00", "06:00", "09:00", "12:00")]
+        s = self._daily(runs=runs)
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9, 17)), self._at(12))
+        self.assertEqual(sched.next_pump_run(s, now=self._at(0, 30)), self._at(1))
+
+    def test_next_pump_run_rolls_into_tomorrow(self):
+        s = self._daily(runs=[{"time": "01:00", "duration": 3}])
+        expected = datetime.datetime(2026, 9, 1, 1, 0)  # the Tuesday after our Monday
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9)), expected)
+
+    def test_next_pump_run_none_when_disabled_or_empty(self):
+        self.assertIsNone(sched.next_pump_run(self._daily(runs=[], pump=False), now=self._at(9)))
+        self.assertIsNone(sched.next_pump_run(self._daily(runs=[]), now=self._at(9)))
+
+    def test_next_pump_run_uses_vacation_profile(self):
+        s = self._daily(runs=[{"time": "01:00", "duration": 3}])
+        s["vacation"] = {"enabled": True, "until": None}
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9)), self._at(12))


### PR DESCRIPTION
**Stacks on #100 and #101** — merge those first; their commits appear here too.

### Problem
The writable "Pump Run Time" entity is fed by `_everyday_pump()`, which can only express **a single run per day**. On a multi-cycle schedule it shows the first run of the day and never moves.

On a tower watering seven times a day (01:00, 06:00, 09:00, 12:00, 15:00, 18:00, 21:00) the Home Assistant dashboard sat frozen on **1:00 AM** all day, with nothing indicating when the next run actually was.

### Fix
A read-only **Next Pump Run** sensor on `schedule/pump/next`, published as ISO 8601 with a UTC offset so HA's `timestamp` device_class renders it as a relative time ("in 2 hours").

`next_pump_run()` walks forward from now, rolls into following days once today's runs are done, and honours Vacation mode.

This is deliberately a **separate sensor rather than a change to the existing entity**. That one is writable, and editing it rewrites every day down to the single run it can express, silently discarding the rest — so leaving it untouched keeps this purely additive. (Making that entity safe on multi-cycle schedules is a bigger change and a separate discussion.)

Refreshed whenever schedule state is published, and — because it has to advance once a run has passed — on change from the actuator poll loop added in #101.

### Verified against the live broker
At 09:22, after the tower's 09:00 run:
```
gardyn/schedule/pump/next = 2026-08-31T12:00:00-04:00
gardyn/schedule/pump/time = 01:00:00      <- the old static entity, unchanged
```

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **146 tests, OK** (adds 4: skipping runs already past, rolling into the next day, none when disabled or empty, and the vacation profile); `ruff check .` and `black --check .` clean.


---

### Related issues
Contributes to **#63** (Home Assistant dashboard cards) — adds a `timestamp` sensor that renders as a relative time, usable directly on a card, where the existing writable entity showed a value frozen on the first run of the day.


Also adjacent to **#32** (schedule API endpoints): adds `next_pump_run()` to the schedule library, surfaced here over MQTT only — **no REST endpoint is added**. See the gap notes on #32.
