### PR TITLE
fix(hardware,mqtt,schedule): truthful actuator state, power-loss recovery, and safe schedule edits

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -52,6 +52,7 @@ OVER_TEMP_HYSTERESIS=34
 WATER_LOW_CM=11
 # How often (s) to re-read the tank and refresh the low-water alert.
 WATER_CHECK_SECONDS=180
+ACTUATOR_POLL_SECONDS=15
 # Tank geometry for the gallons readout: sensor->surface distance (cm) when full
 # vs empty, and capacity in gallons (Home ~5, Studio ~4). Calibrate to your unit.
 WATER_FULL_CM=5

--- a/app/lib/hardware.py
+++ b/app/lib/hardware.py
@@ -53,6 +53,35 @@ def get_pin_factory():
     return _pin_factory
 
 
+def current_duty_fraction(pi, pin, default=0):
+    """Read ``pin``'s live PWM duty cycle from pigpiod as a 0..1 fraction.
+
+    ``PWMLED(pin)`` defaults to ``initial_value=0``, so merely constructing a
+    driver writes zero to the pin. Because the route modules instantiate their
+    drivers at import, every start of the REST API used to switch the lights and
+    pump off -- silently undoing whatever the cron schedule had set. Passing this
+    value as ``initial_value`` makes construction observe the pin instead of
+    resetting it. ``initial_value=None`` is not usable here: gpiozero's PWMLED
+    range-checks it and raises TypeError.
+
+    Returns ``default`` when the pin is not in PWM mode or pigpio is unavailable,
+    which is also the off-Pi path.
+    """
+    if pi is None:
+        return default
+    try:
+        duty = pi.get_PWM_dutycycle(pin)
+        span = pi.get_PWM_range(pin)
+    except Exception as exc:  # noqa: BLE001 - any pigpio error means "unknown"
+        logger.debug("Could not read PWM duty for pin %s: %s", pin, exc)
+        return default
+    try:
+        fraction = float(duty) / float(span)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+    return min(1.0, max(0.0, fraction))
+
+
 def i2c_device_present(address):
     """Return True if an I2C device ACKs at ``address`` on bus 1."""
     try:

--- a/app/sensors/light/light.py
+++ b/app/sensors/light/light.py
@@ -7,6 +7,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -36,8 +37,13 @@ class Light:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.led = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # Open the pigpio client first so the pin's live duty cycle can be read
+        # and handed to PWMLED as its initial value. Without that, constructing
+        # this driver writes 0 and switches the light off -- which happened on
+        # every start of the REST API, undoing the cron schedule.
         self.gpio = GPIOController(pin, pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.led = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/pump/pump.py
+++ b/app/sensors/pump/pump.py
@@ -5,6 +5,7 @@ from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
 
 import config
+from app.lib import hardware
 
 
 class GPIOController:
@@ -34,8 +35,11 @@ class Pump:
         # Note: for docker: PiGPIOFactory(host='pigpiod', port=8888)
         self.pin = pin
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
-        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory)
+        # See Light.__init__: read the live duty cycle before constructing PWMLED
+        # so instantiating this driver cannot cut a scheduled pump run short.
         self.gpio = GPIOController(pin, self.pin_factory)
+        initial = hardware.current_duty_fraction(getattr(self.gpio, "pi", None), pin)
+        self.pump = PWMLED(self.pin, pin_factory=self.pin_factory, initial_value=initial)
         self.set_frequency(frequency)
 
     def on(self):

--- a/app/sensors/schedule/routes.py
+++ b/app/sensors/schedule/routes.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from flask import Blueprint, jsonify, request
@@ -7,6 +8,11 @@ from . import schedule as sched
 logger = logging.getLogger(__name__)
 
 schedule_blueprint = Blueprint("schedule", __name__)
+
+
+def _iso(when):
+    """Local datetime -> ISO 8601 with a UTC offset, or None."""
+    return when.astimezone().isoformat() if when else None
 
 
 @schedule_blueprint.route("", methods=["GET"])
@@ -27,3 +33,72 @@ def set_schedule():
         # crontab binary missing (e.g. off-Pi) — schedule is still saved.
         return jsonify(error="crontab not available on this host"), 503
     return jsonify(applied)
+
+
+@schedule_blueprint.route("/state", methods=["GET"])
+def get_schedule_state():
+    """What the schedule says should be active right now.
+
+    The MQTT service already applies this on connect; exposing it over REST lets
+    the bundled web UI show the same "what is running now" view instead of only
+    the stored times.
+    """
+    schedule = sched.load_schedule()
+    light = sched.expected_light_state(schedule)
+    owed = sched.expected_pump_run(schedule)
+    return jsonify(
+        {
+            "now": datetime.datetime.now().astimezone().isoformat(),
+            "vacation": sched.is_vacation_active(schedule),
+            "light": None if light is None else {"on": light[0], "brightness": light[1]},
+            "pump": {"running": owed is not None, "seconds_remaining": owed},
+        }
+    )
+
+
+@schedule_blueprint.route("/next", methods=["GET"])
+def get_schedule_next():
+    """The next light transition and the next pump run."""
+    schedule = sched.load_schedule()
+    change = sched.next_light_change(schedule)
+    return jsonify(
+        {
+            "light": (
+                None
+                if change is None
+                else {"at": _iso(change[0]), "on": change[1], "brightness": change[2]}
+            ),
+            "pump": {"at": _iso(sched.next_pump_run(schedule))},
+        }
+    )
+
+
+@schedule_blueprint.route("/validate", methods=["POST"])
+def validate_schedule():
+    """Compile a schedule without applying it.
+
+    POST /schedule rewrites the live crontab as a side effect, so there was no
+    way to check a payload first. Returns the cron lines the schedule would
+    install, so a client can diff them against GET /schedule/cron.
+    """
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify(error="expected a JSON schedule object"), 400
+    try:
+        normalized = sched.normalize_schedule(data)
+        lines = sched.build_cron_lines(normalized)
+    except (ValueError, TypeError) as exc:
+        return jsonify(valid=False, error=str(exc)), 400
+    return jsonify(valid=True, count=len(lines), cron_lines=lines, schedule=normalized)
+
+
+@schedule_blueprint.route("/cron", methods=["GET"])
+def get_installed_cron():
+    """The marked cron lines actually installed, for verification.
+
+    Answers "is what is running the same as what is saved?" without shelling
+    into the Pi -- the saved schedule and the installed crontab can diverge if
+    the crontab is edited by hand or an apply failed partway.
+    """
+    lines = sched.installed_cron_lines()
+    return jsonify(count=len(lines), cron_lines=lines)

--- a/app/sensors/schedule/routes.py
+++ b/app/sensors/schedule/routes.py
@@ -102,3 +102,46 @@ def get_installed_cron():
     """
     lines = sched.installed_cron_lines()
     return jsonify(count=len(lines), cron_lines=lines)
+
+
+@schedule_blueprint.route("/pump/once", methods=["GET"])
+def get_one_time_pump_runs():
+    """Pending one-shot pump runs (soonest first)."""
+    runs = sched.one_time_pump_runs()
+    return jsonify(
+        count=len(runs),
+        runs=[{"at": _iso(r["at"]), "seconds": r["seconds"]} for r in runs],
+    )
+
+
+@schedule_blueprint.route("/pump/once", methods=["POST"])
+def add_one_time_pump_run():
+    """Schedule a single pump run at ``time`` ("HH:MM"), today or tomorrow.
+
+    Installs one dated cron entry under its own marker. It does not go through
+    apply_schedule(), so adding a one-off cannot disturb the recurring schedule
+    -- the whole point of having it. ``duration`` defaults to the shortest run
+    already in the schedule, and is capped by MAX_PUMP_RUN_SECONDS either way.
+    """
+    data = request.get_json(silent=True) or {}
+    when = data.get("time")
+    if not isinstance(when, str):
+        return jsonify(error='expected {"time": "HH:MM"}'), 400
+    duration = data.get("duration", sched.default_pump_duration())
+    try:
+        run = sched.add_one_time_pump_run(when, duration)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    except FileNotFoundError:
+        return jsonify(error="crontab not available on this host"), 503
+    return jsonify(at=_iso(run["at"]), seconds=run["seconds"]), 201
+
+
+@schedule_blueprint.route("/pump/once", methods=["DELETE"])
+def clear_one_time_pump_runs():
+    """Cancel every pending one-shot pump run."""
+    try:
+        removed = sched.clear_one_time_pump_runs()
+    except FileNotFoundError:
+        return jsonify(error="crontab not available on this host"), 503
+    return jsonify(removed=removed)

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -308,6 +308,49 @@ def expected_pump_run(schedule, now=None):
     return None
 
 
+def next_light_change(schedule, now=None, lookahead_days=8):
+    """The next light transition after ``now`` as ``(when, on, brightness)``.
+
+    The mirror of expected_light_state, which looks backwards: this walks forward
+    to the soonest on/off event, so a caller can say "on at 65% until 21:00".
+    Returns None when the light schedule is disabled or has no windows.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "lights", now)
+    if days is None:
+        return None
+
+    for delta in range(lookahead_days):
+        date = (now + datetime.timedelta(days=delta)).date()
+        soonest = None
+        for window in days.get(DAYS[date.weekday()], []):
+            brightness = int(window.get("brightness", 70))
+            try:
+                on_m, on_h = _hh_mm(window.get("onTime", "08:00"))
+                off_m, off_h = _hh_mm(window.get("offTime", "22:00"))
+            except (ValueError, AttributeError):
+                continue
+            for stamp, on, level in (
+                (datetime.datetime.combine(date, datetime.time(on_h, on_m)), True, brightness),
+                (datetime.datetime.combine(date, datetime.time(off_h, off_m)), False, 0),
+            ):
+                if stamp > now and (soonest is None or stamp < soonest[0]):
+                    soonest = (stamp, on, level)
+        if soonest is not None:
+            return soonest
+    return None
+
+
+def installed_cron_lines():
+    """The marked cron lines currently installed -- i.e. what will actually run.
+
+    Reads the live crontab rather than recompiling the saved schedule, so a
+    client can verify the two agree. Returns [] when crontab is unavailable.
+    """
+    return [line for line in _read_crontab() if CRON_MARKER in line]
+
+
 def next_pump_run(schedule, now=None, lookahead_days=8):
     """When the next scheduled pump run starts, as a naive local datetime.
 

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -34,6 +34,11 @@ from app.lib.persist import write_json_atomic
 logger = logging.getLogger(__name__)
 
 CRON_MARKER = "# garden-of-eden"
+# One-shot pump runs live under their own marker so apply_schedule() never
+# rewrites or removes them, and so a one-off can never be mistaken for part of
+# the recurring schedule. Note it *contains* CRON_MARKER, so every filter on the
+# recurring marker has to exclude this one explicitly.
+ONCE_MARKER = "# garden-of-eden-once"
 LIGHT_CMD = "/usr/local/bin/light"
 WATER_CMD = "/usr/local/bin/water"
 
@@ -348,7 +353,7 @@ def installed_cron_lines():
     Reads the live crontab rather than recompiling the saved schedule, so a
     client can verify the two agree. Returns [] when crontab is unavailable.
     """
-    return [line for line in _read_crontab() if CRON_MARKER in line]
+    return [line for line in _read_crontab() if CRON_MARKER in line and ONCE_MARKER not in line]
 
 
 def next_pump_run(schedule, now=None, lookahead_days=8):
@@ -388,7 +393,9 @@ def apply_schedule(schedule):
     cron_lines = build_cron_lines(schedule)
     save_schedule(schedule)
 
-    existing = [ln for ln in _read_crontab() if CRON_MARKER not in ln]
+    # Keep foreign lines, and keep one-shot runs: adding or applying a recurring
+    # schedule must never cancel a pending one-off.
+    existing = [ln for ln in _read_crontab() if CRON_MARKER not in ln or ONCE_MARKER in ln]
     _write_crontab(existing + cron_lines)
     logger.info("Applied schedule with %d cron entries", len(cron_lines))
     return schedule
@@ -404,4 +411,126 @@ def refresh():
         vacation["enabled"] = False
         schedule["vacation"] = vacation
         logger.info("Vacation mode expired; reverting to the normal schedule")
-    return apply_schedule(schedule)
+    applied = apply_schedule(schedule)
+    # A dated one-shot entry carries no year, so a spent one would fire again in
+    # twelve months. This nightly pass is where they get cleaned up.
+    prune_one_time_pump_runs()
+    return applied
+
+
+# --- One-shot pump runs -------------------------------------------------------
+# A dated cron entry ("M H D Mon *") fires on a specific day, which is how a
+# single run survives a reboot without a daemon holding a timer. Cron has no
+# concept of "once", though, so the entry would fire again next year: each line
+# carries its full ISO timestamp after the marker, and prune_one_time_pump_runs()
+# drops the ones that have passed.
+
+
+def _parse_once_line(line):
+    """Extract ``(when, seconds)`` from a one-shot cron line, or None."""
+    if ONCE_MARKER not in line:
+        return None
+    head, _, tail = line.partition(ONCE_MARKER)
+    stamp = tail.split()[0] if tail.split() else ""
+    try:
+        when = datetime.datetime.fromisoformat(stamp)
+    except ValueError:
+        return None
+    fields = head.split()
+    try:
+        # M H D Mon DOW CMD SECONDS
+        seconds = int(fields[6])
+    except (IndexError, ValueError):
+        return None
+    return when, seconds
+
+
+def next_occurrence(hhmm, now=None):
+    """The next datetime matching ``"HH:MM"`` -- today if still ahead, else tomorrow."""
+    now = now or datetime.datetime.now()
+    minute, hour = _hh_mm(hhmm)
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= now:
+        candidate += datetime.timedelta(days=1)
+    return candidate
+
+
+def one_time_pump_runs(now=None):
+    """Pending one-shot pump runs, soonest first. Expired entries are excluded."""
+    now = now or datetime.datetime.now()
+    runs = []
+    for line in _read_crontab():
+        parsed = _parse_once_line(line)
+        if parsed and parsed[0] > now:
+            runs.append({"at": parsed[0], "seconds": parsed[1]})
+    return sorted(runs, key=lambda run: run["at"])
+
+
+def prune_one_time_pump_runs(now=None, write=True):
+    """Drop one-shot lines whose time has passed; returns the lines to keep.
+
+    ``write=False`` computes the survivors without touching crontab, so a caller
+    that is about to write anyway does not need two passes.
+    """
+    now = now or datetime.datetime.now()
+    lines = _read_crontab()
+    if not lines:
+        # crontab unreadable (or genuinely empty) -- never write [] over it.
+        return []
+    kept = []
+    for line in lines:
+        parsed = _parse_once_line(line)
+        if parsed and parsed[0] <= now:
+            logger.info("Pruning expired one-time pump run: %s", parsed[0].isoformat())
+            continue
+        kept.append(line)
+    if write and len(kept) != len(lines):
+        _write_crontab(kept)
+    return kept
+
+
+def add_one_time_pump_run(hhmm, duration_minutes, now=None):
+    """Install one dated cron entry for a single pump run.
+
+    Deliberately does **not** go through apply_schedule(): adding a one-off must
+    never rewrite the recurring schedule. Duration is clamped by the same
+    MAX_PUMP_RUN_SECONDS cap as every other path.
+    """
+    when = next_occurrence(hhmm, now)
+    seconds = _pump_seconds(duration_minutes)
+    line = (
+        f"{when.minute} {when.hour} {when.day} {when.month} * "
+        f"{WATER_CMD} {seconds} {ONCE_MARKER} {when.isoformat()}"
+    )
+    kept = prune_one_time_pump_runs(now=now, write=False)
+    _write_crontab(kept + [line])
+    logger.info("Scheduled a one-time pump run at %s for %ss", when.isoformat(), seconds)
+    return {"at": when, "seconds": seconds}
+
+
+def clear_one_time_pump_runs():
+    """Remove every pending one-shot run. Returns how many lines were removed."""
+    lines = _read_crontab()
+    if not lines:
+        return 0
+    kept = [line for line in lines if ONCE_MARKER not in line]
+    removed = len(lines) - len(kept)
+    if removed:
+        _write_crontab(kept)
+    return removed
+
+
+def default_pump_duration(schedule=None):
+    """Duration (minutes) to use for a run when the caller does not specify one.
+
+    The shortest run already in the schedule, so a one-off inherits the rhythm
+    the tower is already on rather than a hardcoded guess. Falls back to 3.
+    """
+    schedule = normalize_schedule(schedule or load_schedule())
+    durations = [
+        int(run.get("duration", 0))
+        for day in DAYS
+        for run in schedule["pump"]["days"].get(day, [])
+        if int(run.get("duration", 0)) > 0
+    ]
+    return min(durations) if durations else 3

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -308,6 +308,36 @@ def expected_pump_run(schedule, now=None):
     return None
 
 
+def next_pump_run(schedule, now=None, lookahead_days=8):
+    """When the next scheduled pump run starts, as a naive local datetime.
+
+    Returns None when the pump schedule is disabled or has no runs. This exists
+    because the writable "Pump Run Time" entity can only express a single run per
+    day: on a multi-cycle schedule it shows the first run and never moves, so a
+    dashboard reading it appears frozen.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "pump", now)
+    if days is None:
+        return None
+
+    for delta in range(lookahead_days):
+        date = (now + datetime.timedelta(days=delta)).date()
+        soonest = None
+        for run in days.get(DAYS[date.weekday()], []):
+            try:
+                run_m, run_h = _hh_mm(run.get("time", "12:00"))
+            except (ValueError, AttributeError):
+                continue
+            start = datetime.datetime.combine(date, datetime.time(run_h, run_m))
+            if start > now and (soonest is None or start < soonest):
+                soonest = start
+        if soonest is not None:
+            return soonest
+    return None
+
+
 def apply_schedule(schedule):
     """Persist the schedule and replace our crontab entries with its compiled form."""
     # Validate/compile first so a bad schedule never touches crontab.

--- a/app/sensors/schedule/schedule.py
+++ b/app/sensors/schedule/schedule.py
@@ -230,6 +230,84 @@ def _write_crontab(lines):
     subprocess.run(["crontab", "-"], input=payload, text=True, check=True)
 
 
+def _effective_days(schedule, kind, now):
+    """The day map in force for ``kind`` ("lights"/"pump"), honouring Vacation
+    mode, or None when that half of the schedule is switched off."""
+    if is_vacation_active(schedule, today=now.date()):
+        return {day: list(VACATION_PROFILE[kind]) for day in DAYS}
+    section = schedule.get(kind) or {}
+    if not section.get("enabled"):
+        return None
+    return section.get("days") or _empty_days()
+
+
+def expected_light_state(schedule, now=None, lookback_days=8):
+    """What the compiled schedule has the light doing at ``now``.
+
+    Returns ``(on, brightness)``, or ``None`` when the schedule expresses no
+    opinion (lights disabled, or no windows at all) so callers leave the pin be.
+
+    This deliberately replays the crontab's own semantics -- the most recent
+    on/off event at or before ``now`` wins -- rather than interpreting each
+    window as an interval. Windows that run past midnight, several windows in
+    one day, and deliberate gaps then all agree with what cron actually did.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "lights", now)
+    if days is None:
+        return None
+
+    latest = None
+    for delta in range(lookback_days):
+        date = (now - datetime.timedelta(days=delta)).date()
+        for window in days.get(DAYS[date.weekday()], []):
+            brightness = int(window.get("brightness", 70))
+            try:
+                on_m, on_h = _hh_mm(window.get("onTime", "08:00"))
+                off_m, off_h = _hh_mm(window.get("offTime", "22:00"))
+            except (ValueError, AttributeError):
+                continue
+            for stamp, on, level in (
+                (datetime.datetime.combine(date, datetime.time(on_h, on_m)), True, brightness),
+                (datetime.datetime.combine(date, datetime.time(off_h, off_m)), False, 0),
+            ):
+                if stamp <= now and (latest is None or stamp > latest[0]):
+                    latest = (stamp, on, level)
+
+    if latest is None:
+        return None
+    return latest[1], latest[2]
+
+
+def expected_pump_run(schedule, now=None):
+    """Seconds still owed to a pump run that should be under way at ``now``.
+
+    Returns ``None`` when no run is in progress. Reported rather than acted on
+    automatically: a service that crash-loops would otherwise restart the pump
+    on every boot, and a missed run self-heals at the next scheduled one.
+    """
+    now = now or datetime.datetime.now()
+    schedule = normalize_schedule(schedule)
+    days = _effective_days(schedule, "pump", now)
+    if days is None:
+        return None
+
+    for delta in (0, 1):  # today, and yesterday for a run spanning midnight
+        date = (now - datetime.timedelta(days=delta)).date()
+        for run in days.get(DAYS[date.weekday()], []):
+            try:
+                run_m, run_h = _hh_mm(run.get("time", "12:00"))
+                seconds = _pump_seconds(run.get("duration", 5))
+            except (ValueError, AttributeError, TypeError):
+                continue
+            start = datetime.datetime.combine(date, datetime.time(run_h, run_m))
+            remaining = (start + datetime.timedelta(seconds=seconds) - now).total_seconds()
+            if 0 < remaining <= seconds:
+                return int(remaining)
+    return None
+
+
 def apply_schedule(schedule):
     """Persist the schedule and replace our crontab entries with its compiled form."""
     # Validate/compile first so a bad schedule never touches crontab.

--- a/config.py
+++ b/config.py
@@ -122,6 +122,12 @@ WATER_LOW_CM = _get_float("WATER_LOW_CM", 0) or None
 # low-water alert. Kept short so a transient false alarm self-clears quickly.
 WATER_CHECK_SECONDS = _get_int("WATER_CHECK_SECONDS", 180)
 
+# How often (seconds) the MQTT service re-reads the light/pump duty cycles and
+# republishes them. cron, the REST API, the CLI and the physical button all drive
+# the hardware without going through the MQTT service, so without polling Home
+# Assistant drifts out of step with reality. 0 disables the poll.
+ACTUATOR_POLL_SECONDS = _get_int("ACTUATOR_POLL_SECONDS", 15)
+
 # Tank geometry for the cm->gallons readout: distance (cm) from the sensor to the
 # water surface when the tank is full vs empty, and the tank capacity in gallons
 # (Gardyn Home ~5 gal, Studio ~4 gal). Calibrate FULL/EMPTY to your unit.

--- a/mqtt.py
+++ b/mqtt.py
@@ -912,13 +912,49 @@ def _set_schedule_flag(client, section, enabled):
     _apply_schedule(client, schedule)
 
 
-def _set_everyday_light(client, **changes):
-    """Update the everyday light window (one field) and write it to all 7 days."""
+def _set_light_brightness(client, brightness):
+    """Set brightness on every existing window, preserving each window's times.
+
+    The counterpart of _set_pump_duration: brightness is a property of each
+    window rather than a description of the day, so it applies to all of them
+    and the window count is untouched.
+    """
     schedule = sched_lib.normalize_schedule(sched_lib.load_schedule())
-    window = _everyday_light(schedule)
-    window.update(changes)
+    touched = 0
     for day in sched_lib.DAYS:
-        schedule["lights"]["days"][day] = [dict(window)]
+        for window in schedule["lights"]["days"][day]:
+            window["brightness"] = brightness
+            touched += 1
+    if not touched:
+        # Nothing scheduled yet, so seed a window per day rather than doing nothing.
+        seed = _everyday_light(schedule)
+        seed["brightness"] = brightness
+        for day in sched_lib.DAYS:
+            schedule["lights"]["days"][day] = [dict(seed)]
+    logger.info("Set light brightness to %s%% across %s existing window(s)", brightness, touched)
+    _apply_schedule(client, schedule)
+
+
+def _set_light_first_window(client, **changes):
+    """Move the *first* window of each day, leaving any later windows untouched.
+
+    The counterpart of _set_pump_first_time. A single on/off pair cannot express
+    a multi-window day, so this previously wrote one window over all seven days
+    and silently discarded the rest -- the same defect the pump setters carried.
+    Moving one window is a predictable, reversible edit; collapsing the day to
+    it is not.
+    """
+    schedule = sched_lib.normalize_schedule(sched_lib.load_schedule())
+    # Resolved once: appending to an empty day would otherwise change what the
+    # representative window is for the days after it.
+    seed = _everyday_light(schedule)
+    for day in sched_lib.DAYS:
+        windows = schedule["lights"]["days"][day]
+        if windows:
+            windows[0].update(changes)
+        else:
+            windows.append({**seed, **changes})
+    logger.info("Updated the first light window of each day: %s", changes)
     _apply_schedule(client, schedule)
 
 
@@ -1088,15 +1124,18 @@ def on_message(client, userdata, msg):
         elif topic_suffix == "schedule/vacation/enabled/set":
             _set_schedule_flag(client, "vacation", payload.upper() == "ON")
 
-        # === Everyday schedule setters (write one window/run to all 7 days) ===
+        # === Everyday schedule setters ===
+        # Each edits the saved schedule in place rather than replacing it: a
+        # scalar from HA cannot express a multi-window/multi-run day, so none of
+        # these may collapse one. See the setters for what each touches.
         elif topic_suffix == "schedule/lights/on/set":
-            _set_everyday_light(client, onTime=_time_from_ha(payload))
+            _set_light_first_window(client, onTime=_time_from_ha(payload))
 
         elif topic_suffix == "schedule/lights/off/set":
-            _set_everyday_light(client, offTime=_time_from_ha(payload))
+            _set_light_first_window(client, offTime=_time_from_ha(payload))
 
         elif topic_suffix == "schedule/lights/brightness/set" and payload.isdigit():
-            _set_everyday_light(client, brightness=max(0, min(100, int(payload))))
+            _set_light_brightness(client, max(0, min(100, int(payload))))
 
         elif topic_suffix == "schedule/pump/time/set":
             _set_pump_first_time(client, _time_from_ha(payload))

--- a/mqtt.py
+++ b/mqtt.py
@@ -16,7 +16,7 @@ from gpiozero import Button  # Import gpiozero Button
 
 from app.lib import grow as grow_lib
 from app.lib import state as state_lib
-from app.lib.hardware import detect_model, get_pin_factory
+from app.lib.hardware import current_duty_fraction, detect_model, get_pin_factory
 from app.lib.logging_config import configure_logging
 from app.lib.water import is_water_low
 from app.sensors.camera import camera as camera_mod
@@ -29,6 +29,7 @@ from app.sensors.pump.routes import pump_control
 from app.sensors.schedule import schedule as sched_lib
 from app.sensors.temperature.temperature import temperature_sensor
 from config import (
+    ACTUATOR_POLL_SECONDS,
     BASE_TOPIC,
     BROKER,
     BUTTON_PIN,
@@ -1104,6 +1105,127 @@ def restore_actuator_state(client):
         logger.error("Failed to restore actuator state: %s", exc)
 
 
+def reconcile_actuator_state(client):
+    """Republish the actuators' real duty cycles on a timer.
+
+    cron, the REST API, the CLI and the physical button all drive the hardware
+    without passing through this service, so a service that only publishes what
+    it commanded drifts: Home Assistant showed the light OFF while it was on at
+    65%, and the pump OFF through a scheduled run. gpiozero reads PWM duty back
+    through pigpiod, so polling reports the truth whoever made the change.
+
+    The duty cycles are read straight from pigpiod (silently) and only a change
+    triggers a publish, so this neither spams the broker nor the log. It also
+    refreshes the persisted actuator state, which the cron path never touches --
+    that stale file is why power-loss recovery could not restore a scheduled
+    light.
+    """
+    global light_state, pump_state, brightness, speed
+    interval = ACTUATOR_POLL_SECONDS
+    if not interval:
+        logger.info("Actuator polling disabled (ACTUATOR_POLL_SECONDS=0)")
+        return
+
+    last = None
+    while True:
+        try:
+            light_pct = _live_duty_percent(light)
+            pump_pct = _live_duty_percent(pump)
+            snapshot = (light_pct, pump_pct)
+            if None not in snapshot and snapshot != last:
+                # Published straight from the polled percentages rather than via a
+                # helper that re-reads the pins, so this needs nothing beyond the
+                # topics the light/pump discovery already declares.
+                client.publish(
+                    BASE_TOPIC + "/light/state", "ON" if light_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/light/brightness/state", str(light_pct), retain=True)
+                client.publish(
+                    BASE_TOPIC + "/pump/state", "ON" if pump_pct > 0 else "OFF", retain=True
+                )
+                client.publish(BASE_TOPIC + "/pump/speed/state", str(pump_pct), retain=True)
+                logger.info(
+                    "Actuator state: light %s at %s%%, pump %s at %s%%",
+                    "ON" if light_pct > 0 else "OFF",
+                    light_pct,
+                    "ON" if pump_pct > 0 else "OFF",
+                    pump_pct,
+                )
+                light_state = light_pct > 0
+                pump_state = pump_pct > 0
+                if light_pct > 0:
+                    brightness = light_pct
+                if pump_pct > 0:
+                    speed = pump_pct
+                state_lib.save_state(
+                    light_on=light_state,
+                    brightness=brightness,
+                    pump_on=pump_state,
+                    speed=speed,
+                )
+                last = snapshot
+        except Exception:
+            logger.exception("Error reconciling actuator state")
+        sleep(interval)
+
+
+def _live_duty_percent(driver):
+    """A driver's current duty cycle as a whole percent, read from pigpiod.
+
+    Deliberately silent -- the drivers' own getters log on every call, which at
+    poll frequency would bury the log. Returns None when it cannot be read.
+    """
+    fraction = current_duty_fraction(getattr(driver.gpio, "pi", None), driver.pin, default=None)
+    return None if fraction is None else int(round(fraction * 100))
+
+
+def apply_scheduled_state(client):
+    """Bring the light in line with what the schedule says should be on now.
+
+    Cron drives the actuators through the ``light``/``water`` CLIs, which never
+    touch the persisted actuator state, so ``restore_actuator_state`` can only
+    ever recover a state some MQTT/HA action last wrote. After a power cut in the
+    middle of a photoperiod that leaves the tower dark until the next scheduled
+    on-time -- up to a full day. Replaying the schedule's current expectation on
+    startup closes that gap, and runs after the saved-state restore so the
+    schedule wins over a stale value.
+
+    The pump is reported but deliberately not started: this runs on every
+    connect, and a service that crash-loops would otherwise re-trigger watering
+    each time, whereas a missed run self-heals at the next scheduled one.
+    """
+    global light_state, brightness
+    try:
+        schedule = sched_lib.load_schedule()
+        expected = sched_lib.expected_light_state(schedule)
+        if expected is None:
+            logger.info("Schedule has no light opinion; leaving the light as-is")
+        else:
+            should_be_on, level = expected
+            if should_be_on:
+                light_state = True
+                brightness = level
+                light.set_duty_cycle(level)
+                client.publish(BASE_TOPIC + "/light/state", "ON")
+                client.publish(BASE_TOPIC + "/light/brightness", str(level))
+            else:
+                light_state = False
+                light.off()
+                client.publish(BASE_TOPIC + "/light/state", "OFF")
+            state_lib.save_state(light_on=light_state, brightness=brightness)
+            logger.info("Applied scheduled light state: on=%s brightness=%s", should_be_on, level)
+
+        owed = sched_lib.expected_pump_run(schedule)
+        if owed:
+            logger.warning(
+                "A scheduled pump run has %ss left; not auto-starting it. "
+                "Next scheduled run will proceed normally.",
+                owed,
+            )
+    except Exception:
+        logger.exception("Error applying scheduled state")
+
+
 def publish_grow_reminders(client):
     """Publish grow stage and any due reminders (thinning/root/harvest/nutrient)."""
     while True:
@@ -1182,10 +1304,17 @@ if __name__ == "__main__":
     grow_thread.daemon = True
     grow_thread.start()
 
-    # Restore last known actuator state after (re)connect.
+    actuator_thread = threading.Thread(target=reconcile_actuator_state, args=(client,))
+    actuator_thread.daemon = True
+    actuator_thread.start()
+
+    # Restore last known actuator state after (re)connect, then let the schedule
+    # override it -- cron-driven changes never reach the persisted state, so the
+    # schedule is the more trustworthy source for what should be on right now.
     client.on_connect = lambda c, u, f, rc, properties=None: (
         on_connect(c, u, f, rc, properties),
         restore_actuator_state(c),
+        apply_scheduled_state(c),
     )
 
     client.loop_forever()

--- a/mqtt.py
+++ b/mqtt.py
@@ -595,6 +595,20 @@ def send_discovery_messages(client):
             "device": device_info,
         },
     )
+    # Read-only companion to the writable "Pump Run Time" entity, which can only
+    # express one run per day and so sits frozen on the first of a multi-cycle
+    # schedule. device_class timestamp lets HA render it as "in 2 hours".
+    pub(
+        f"homeassistant/sensor/gardyn/{IDENTIFIER}_pump_next_run/config",
+        {
+            "name": "Next Pump Run",
+            "unique_id": IDENTIFIER + "_pump_next_run",
+            "state_topic": BASE_TOPIC + "/schedule/pump/next",
+            "device_class": "timestamp",
+            "icon": "mdi:clock-fast",
+            "device": device_info,
+        },
+    )
     pub(
         f"homeassistant/button/gardyn/{IDENTIFIER}_grow_start/config",
         {
@@ -776,6 +790,24 @@ def publish_schedule_state(client):
         )
     except Exception:
         logger.exception("Error publishing schedule state")
+    publish_next_pump_run(client)
+
+
+def _next_pump_payload():
+    """The next scheduled pump run as ISO 8601 with a UTC offset, which is what
+    Home Assistant's timestamp device_class needs to render a relative time
+    ("in 2 hours"). "unavailable" when the pump schedule is off or empty."""
+    try:
+        upcoming = sched_lib.next_pump_run(sched_lib.load_schedule())
+    except Exception:
+        logger.exception("Error computing the next pump run")
+        return "unavailable"
+    return upcoming.astimezone().isoformat() if upcoming else "unavailable"
+
+
+def publish_next_pump_run(client):
+    """Publish when the next scheduled pump run starts."""
+    client.publish(BASE_TOPIC + "/schedule/pump/next", _next_pump_payload(), retain=True)
 
 
 def _apply_schedule(client, schedule):
@@ -1127,8 +1159,16 @@ def reconcile_actuator_state(client):
         return
 
     last = None
+    last_next_run = None
     while True:
         try:
+            # The next-run sensor has to advance once a run has passed. It changes
+            # only a handful of times a day, so publish it only when it moves.
+            upcoming = _next_pump_payload()
+            if upcoming != last_next_run:
+                client.publish(BASE_TOPIC + "/schedule/pump/next", upcoming, retain=True)
+                last_next_run = upcoming
+
             light_pct = _live_duty_percent(light)
             pump_pct = _live_duty_percent(pump)
             snapshot = (light_pct, pump_pct)

--- a/mqtt.py
+++ b/mqtt.py
@@ -103,6 +103,9 @@ button = Button(
 # Variables to track the state of the light and pump
 light_state = False
 pump_state = False
+# Time used by the "One-Time Pump Run" button. Persisted so it survives a
+# restart, since the button is useless if the time it fires at is forgotten.
+manual_pump_time = state_lib.load_state().get("manual_pump_time") or "12:00"
 double_press_time = 1  # Time to detect a double press (in seconds)
 press_count = 0
 double_press_timer = None
@@ -595,6 +598,44 @@ def send_discovery_messages(client):
             "device": device_info,
         },
     )
+    # Arms a single dated cron entry at "Manual Pump Run Time". Adding a one-off
+    # deliberately does not touch the recurring schedule.
+    pub(
+        f"homeassistant/button/gardyn/{IDENTIFIER}_pump_run_once/config",
+        {
+            "name": "One-Time Pump Run",
+            "unique_id": IDENTIFIER + "_pump_run_once",
+            "command_topic": BASE_TOPIC + "/schedule/pump/manual/run/set",
+            "icon": "mdi:water-plus-outline",
+            "device": device_info,
+        },
+    )
+    pub(
+        f"homeassistant/sensor/gardyn/{IDENTIFIER}_pump_once_next/config",
+        {
+            "name": "Pending One-Time Pump Run",
+            "unique_id": IDENTIFIER + "_pump_once_next",
+            "state_topic": BASE_TOPIC + "/schedule/pump/once/next",
+            "device_class": "timestamp",
+            "icon": "mdi:calendar-clock",
+            "device": device_info,
+        },
+    )
+    # The real hard cap, enforced in code on every path (MQTT, REST, CLI, cron).
+    # Read-only on purpose: it is a safety limit, not a per-run setting -- unlike
+    # "Pump Run Duration", which is the duration of each scheduled run.
+    pub(
+        f"homeassistant/sensor/gardyn/{IDENTIFIER}_pump_max_seconds/config",
+        {
+            "name": "Max Pump Run Time",
+            "unique_id": IDENTIFIER + "_pump_max_seconds",
+            "state_topic": BASE_TOPIC + "/schedule/pump/max_seconds",
+            "unit_of_measurement": "s",
+            "device_class": "duration",
+            "icon": "mdi:timer-lock-outline",
+            "device": device_info,
+        },
+    )
     # Read-only companion to the writable "Pump Run Time" entity, which can only
     # express one run per day and so sits frozen on the first of a multi-cycle
     # schedule. device_class timestamp lets HA render it as "in 2 hours".
@@ -689,6 +730,14 @@ def send_discovery_messages(client):
             {"min": 0, "max": 100, "step": 1, "unit_of_measurement": "%"},
         ),
         ("time", "sched_pump_time", "Pump Run Time", "schedule/pump/time", "mdi:water-pump", {}),
+        (
+            "time",
+            "sched_pump_manual_time",
+            "Manual Pump Run Time",
+            "schedule/pump/manual/time",
+            "mdi:water-plus",
+            {},
+        ),
         (
             "number",
             "sched_pump_duration",
@@ -791,6 +840,42 @@ def publish_schedule_state(client):
     except Exception:
         logger.exception("Error publishing schedule state")
     publish_next_pump_run(client)
+    publish_one_time_state(client)
+
+
+def publish_one_time_state(client):
+    """Publish the manual-run time, the pending one-off, and the hard cap."""
+    try:
+        client.publish(
+            BASE_TOPIC + "/schedule/pump/manual/time", _time_to_ha(manual_pump_time), retain=True
+        )
+        client.publish(
+            BASE_TOPIC + "/schedule/pump/max_seconds", str(MAX_PUMP_RUN_SECONDS), retain=True
+        )
+        pending = sched_lib.one_time_pump_runs()
+        payload = pending[0]["at"].astimezone().isoformat() if pending else "unavailable"
+        client.publish(BASE_TOPIC + "/schedule/pump/once/next", payload, retain=True)
+    except Exception:
+        logger.exception("Error publishing one-time pump run state")
+
+
+def arm_one_time_pump_run(client):
+    """Install a single dated cron entry at the manual run time.
+
+    Routed through sched_lib.add_one_time_pump_run(), which writes its own
+    marked line rather than going through apply_schedule() -- so pressing this
+    can never rewrite or discard the recurring schedule.
+    """
+    try:
+        run = sched_lib.add_one_time_pump_run(manual_pump_time, sched_lib.default_pump_duration())
+        logger.info(
+            "Armed a one-time pump run at %s for %ss", run["at"].isoformat(), run["seconds"]
+        )
+    except ValueError as exc:
+        logger.warning("Rejected one-time pump run: %s", exc)
+    except FileNotFoundError:
+        logger.error("Cannot arm a one-time pump run: crontab unavailable")
+    publish_one_time_state(client)
 
 
 def _next_pump_payload():
@@ -837,13 +922,42 @@ def _set_everyday_light(client, **changes):
     _apply_schedule(client, schedule)
 
 
-def _set_everyday_pump(client, **changes):
-    """Update the everyday pump run (one field) and write it to all 7 days."""
+def _set_pump_duration(client, minutes):
+    """Set the duration on every existing run, preserving each run's time.
+
+    The previous behaviour rewrote all seven days down to a single run, so
+    nudging the duration control silently discarded a multi-cycle schedule --
+    seven 3-minute runs became one. This keeps every run and changes only how
+    long each lasts, which is what the control appears to promise.
+    """
     schedule = sched_lib.normalize_schedule(sched_lib.load_schedule())
-    run = _everyday_pump(schedule)
-    run.update(changes)
+    touched = 0
     for day in sched_lib.DAYS:
-        schedule["pump"]["days"][day] = [dict(run)]
+        for run in schedule["pump"]["days"][day]:
+            run["duration"] = minutes
+            touched += 1
+    if not touched:
+        # Nothing scheduled yet, so seed a run per day rather than doing nothing.
+        for day in sched_lib.DAYS:
+            schedule["pump"]["days"][day] = [{"time": "12:00", "duration": minutes}]
+    logger.info("Set pump duration to %s min across %s existing run(s)", minutes, touched)
+    _apply_schedule(client, schedule)
+
+
+def _set_pump_first_time(client, hhmm):
+    """Move the *first* run of each day, leaving any later runs untouched.
+
+    A single scalar cannot express a multi-run day. Moving one run is a
+    predictable, reversible edit; collapsing the day to it is not.
+    """
+    schedule = sched_lib.normalize_schedule(sched_lib.load_schedule())
+    for day in sched_lib.DAYS:
+        runs = schedule["pump"]["days"][day]
+        if runs:
+            runs[0]["time"] = hhmm
+        else:
+            runs.append({"time": hhmm, "duration": sched_lib.default_pump_duration(schedule)})
+    logger.info("Moved the first pump run of each day to %s", hhmm)
     _apply_schedule(client, schedule)
 
 
@@ -863,7 +977,7 @@ def on_connect(client, userdata, flags, rc, properties=None):
 
 
 def on_message(client, userdata, msg):
-    global brightness, speed, WATER_LOW_CM
+    global brightness, speed, WATER_LOW_CM, manual_pump_time
 
     # Handle binary payloads (like image topics) — skip decoding
     if msg.topic.endswith("/image/upper_camera") or msg.topic.endswith("/image/lower_camera"):
@@ -985,10 +1099,18 @@ def on_message(client, userdata, msg):
             _set_everyday_light(client, brightness=max(0, min(100, int(payload))))
 
         elif topic_suffix == "schedule/pump/time/set":
-            _set_everyday_pump(client, time=_time_from_ha(payload))
+            _set_pump_first_time(client, _time_from_ha(payload))
 
         elif topic_suffix == "schedule/pump/duration/set" and payload.isdigit():
-            _set_everyday_pump(client, duration=max(1, min(5, int(payload))))
+            _set_pump_duration(client, max(1, min(5, int(payload))))
+
+        elif topic_suffix == "schedule/pump/manual/time/set":
+            manual_pump_time = _time_from_ha(payload)
+            state_lib.save_state(manual_pump_time=manual_pump_time)
+            publish_one_time_state(client)
+
+        elif topic_suffix == "schedule/pump/manual/run/set":
+            arm_one_time_pump_run(client)
 
     except ValueError as e:
         logger.warning(f"Rejected message on topic {msg.topic}: {e}")

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -44,5 +44,46 @@ class SystemRouteTestCase(unittest.TestCase):
         self.assertEqual(body["profile"], config.MODELS["gardyn 3.0"])
 
 
+class CurrentDutyFractionTestCase(unittest.TestCase):
+    """Constructing a driver must observe the pin, not reset it.
+
+    PWMLED defaults to initial_value=0, so before this helper existed every
+    start of the REST API wrote 0 to the light and pump pins and undid whatever
+    the cron schedule had set.
+    """
+
+    class _Pi:
+        def __init__(self, duty, span):
+            self._duty, self._span = duty, span
+
+        def get_PWM_dutycycle(self, _pin):
+            if isinstance(self._duty, Exception):
+                raise self._duty
+            return self._duty
+
+        def get_PWM_range(self, _pin):
+            return self._span
+
+    def test_reads_live_duty_as_a_fraction(self):
+        self.assertAlmostEqual(hardware.current_duty_fraction(self._Pi(6500, 10000), 18), 0.65)
+
+    def test_off_pin_reads_zero(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(0, 10000), 18), 0)
+
+    def test_no_pigpio_client_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(None, 18), 0)
+        self.assertEqual(hardware.current_duty_fraction(None, 18, default=1), 1)
+
+    def test_pin_not_in_pwm_mode_falls_back(self):
+        pi = self._Pi(Exception("GPIO not set up for PWM"), 10000)
+        self.assertEqual(hardware.current_duty_fraction(pi, 18), 0)
+
+    def test_zero_range_falls_back(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(100, 0), 18), 0)
+
+    def test_result_is_clamped(self):
+        self.assertEqual(hardware.current_duty_fraction(self._Pi(20000, 10000), 18), 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mqtt_control.py
+++ b/tests/test_mqtt_control.py
@@ -121,6 +121,73 @@ class MqttControlTestCase(unittest.TestCase):
         self.assertEqual(mon["onTime"], "23:00")
         self.assertEqual(mon["brightness"], 60)
 
+    # --- a scalar from HA must never collapse a multi-window/multi-run day ---
+    # These setters describe one window/run, but the schedule they edit can hold
+    # several a day. Both used to write their single value over all seven days,
+    # silently discarding the rest; each of the four is now surgical.
+    def _save_two_windows_and_runs(self):
+        self.mqtt.sched_lib.save_schedule(
+            {
+                "lights": {
+                    "enabled": True,
+                    "days": {
+                        "mon": [
+                            {"onTime": "05:00", "offTime": "11:00", "brightness": 65},
+                            {"onTime": "15:00", "offTime": "21:00", "brightness": 40},
+                        ]
+                    },
+                },
+                "pump": {
+                    "enabled": True,
+                    "days": {
+                        "mon": [
+                            {"time": "06:00", "duration": 3},
+                            {"time": "18:00", "duration": 3},
+                        ]
+                    },
+                },
+            }
+        )
+
+    def test_light_time_moves_only_the_first_window(self):
+        self._save_two_windows_and_runs()
+        self.send("schedule/lights/on/set", "04:00:00")
+
+        mon = self.mqtt.sched_lib.load_schedule()["lights"]["days"]["mon"]
+        self.assertEqual(len(mon), 2, "the second window must survive")
+        self.assertEqual(mon[0]["onTime"], "04:00")
+        self.assertEqual(mon[0]["offTime"], "11:00", "the first window keeps its off time")
+        self.assertEqual(mon[1], {"onTime": "15:00", "offTime": "21:00", "brightness": 40})
+
+    def test_light_brightness_applies_to_every_window(self):
+        self._save_two_windows_and_runs()
+        self.send("schedule/lights/brightness/set", "80")
+
+        mon = self.mqtt.sched_lib.load_schedule()["lights"]["days"]["mon"]
+        self.assertEqual(len(mon), 2)
+        self.assertEqual([w["brightness"] for w in mon], [80, 80])
+        # Times are a property of each window and must be left alone.
+        self.assertEqual([w["onTime"] for w in mon], ["05:00", "15:00"])
+        self.assertEqual([w["offTime"] for w in mon], ["11:00", "21:00"])
+
+    def test_pump_time_moves_only_the_first_run(self):
+        self._save_two_windows_and_runs()
+        self.send("schedule/pump/time/set", "01:00:00")
+
+        mon = self.mqtt.sched_lib.load_schedule()["pump"]["days"]["mon"]
+        self.assertEqual(len(mon), 2, "the second run must survive")
+        self.assertEqual(mon[0]["time"], "01:00")
+        self.assertEqual(mon[1], {"time": "18:00", "duration": 3})
+
+    def test_pump_duration_applies_to_every_run(self):
+        self._save_two_windows_and_runs()
+        self.send("schedule/pump/duration/set", "5")
+
+        mon = self.mqtt.sched_lib.load_schedule()["pump"]["days"]["mon"]
+        self.assertEqual(len(mon), 2)
+        self.assertEqual([r["duration"] for r in mon], [5, 5])
+        self.assertEqual([r["time"] for r in mon], ["06:00", "18:00"])
+
     # --- grow cycle ---
     def test_grow_stage_set(self):
         self.send("grow/stage/set", "thinning")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -146,3 +146,75 @@ class NormalizeScheduleTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExpectedStateTestCase(unittest.TestCase):
+    """What the schedule says should be running right now.
+
+    Used on startup to recover from a power cut mid-photoperiod: cron drives the
+    actuators through the CLIs, which never update the persisted actuator state,
+    so without this the tower stays dark until the next scheduled on-time.
+    """
+
+    # 2026-08-31 is a Monday.
+    def _at(self, hour, minute=0, day=31):
+        return datetime.datetime(2026, 8, day, hour, minute)
+
+    def _daily(self, windows=None, runs=None, lights=True, pump=True):
+        return {
+            "lights": {"enabled": lights, "days": {d: list(windows or []) for d in sched.DAYS}},
+            "pump": {"enabled": pump, "days": {d: list(runs or []) for d in sched.DAYS}},
+        }
+
+    def test_inside_window_is_on_at_that_brightness(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (True, 65))
+
+    def test_after_off_time_is_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(22)), (False, 0))
+
+    def test_before_first_on_time_uses_yesterdays_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(3)), (False, 0))
+
+    def test_window_spanning_midnight_follows_cron_semantics(self):
+        # Compiled as "on 23:00" and "off 07:00" on the same weekday, so at 02:00
+        # the most recent event is the previous day's 23:00 on.
+        s = self._daily([{"onTime": "23:00", "offTime": "07:00", "brightness": 80}])
+        self.assertEqual(sched.expected_light_state(s, now=self._at(2)), (True, 80))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(8)), (False, 0))
+
+    def test_latest_of_several_windows_wins(self):
+        s = self._daily(
+            [
+                {"onTime": "05:00", "offTime": "09:00", "brightness": 40},
+                {"onTime": "17:00", "offTime": "21:00", "brightness": 90},
+            ]
+        )
+        self.assertEqual(sched.expected_light_state(s, now=self._at(18)), (True, 90))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (False, 0))
+
+    def test_disabled_or_empty_expresses_no_opinion(self):
+        self.assertIsNone(sched.expected_light_state(self._daily(lights=False), now=self._at(9)))
+        self.assertIsNone(sched.expected_light_state(self._daily([]), now=self._at(9)))
+
+    def test_vacation_profile_overrides(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        s["vacation"] = {"enabled": True, "until": None}
+        # Vacation keeps lights 10:00-16:00 at 50%.
+        self.assertEqual(sched.expected_light_state(s, now=self._at(12)), (True, 50))
+        self.assertEqual(sched.expected_light_state(s, now=self._at(9)), (False, 0))
+
+    def test_pump_run_in_progress_reports_remaining_seconds(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertEqual(sched.expected_pump_run(s, now=self._at(9, 1)), 120)
+
+    def test_pump_run_outside_window_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}])
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 5)))
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(8, 59)))
+
+    def test_pump_disabled_is_none(self):
+        s = self._daily(runs=[{"time": "09:00", "duration": 3}], pump=False)
+        self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 1)))

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -238,3 +238,76 @@ class ExpectedStateTestCase(unittest.TestCase):
         s = self._daily(runs=[{"time": "01:00", "duration": 3}])
         s["vacation"] = {"enabled": True, "until": None}
         self.assertEqual(sched.next_pump_run(s, now=self._at(9)), self._at(12))
+
+    def test_next_light_change_finds_the_upcoming_off(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(sched.next_light_change(s, now=self._at(9)), (self._at(21), False, 0))
+
+    def test_next_light_change_finds_the_upcoming_on(self):
+        s = self._daily([{"onTime": "05:00", "offTime": "21:00", "brightness": 65}])
+        self.assertEqual(
+            sched.next_light_change(s, now=self._at(22)),
+            (self._at(5, day=1).replace(month=9), True, 65),
+        )
+
+    def test_next_light_change_none_when_disabled(self):
+        self.assertIsNone(sched.next_light_change(self._daily(lights=False), now=self._at(9)))
+
+
+class ScheduleEndpointTestCase(unittest.TestCase):
+    """The derived-state and dry-run routes (issue #32)."""
+
+    @classmethod
+    def setUpClass(cls):
+        from app import create_app
+
+        cls.client = create_app("default").test_client()
+
+    def test_state_reports_light_and_pump(self):
+        body = self.client.get("/schedule/state").get_json()
+        self.assertIn("now", body)
+        self.assertIn("vacation", body)
+        self.assertIn("pump", body)
+        self.assertIn("running", body["pump"])
+
+    def test_next_reports_both_actuators(self):
+        body = self.client.get("/schedule/next").get_json()
+        self.assertIn("light", body)
+        self.assertIn("pump", body)
+
+    def test_validate_compiles_without_applying(self):
+        payload = {
+            "lights": {
+                "enabled": True,
+                "days": {
+                    d: [{"onTime": "05:00", "offTime": "21:00", "brightness": 65}]
+                    for d in sched.DAYS
+                },
+            },
+            "pump": {
+                "enabled": True,
+                "days": {d: [{"time": "09:00", "duration": 3}] for d in sched.DAYS},
+            },
+        }
+        body = self.client.post("/schedule/validate", json=payload).get_json()
+        self.assertTrue(body["valid"])
+        # 7 days x (light on + light off + one pump run)
+        self.assertEqual(body["count"], 21)
+        self.assertTrue(any("/usr/local/bin/light 65" in ln for ln in body["cron_lines"]))
+
+    def test_validate_rejects_a_bad_time(self):
+        payload = {
+            "lights": {"enabled": True, "days": {"mon": [{"onTime": "99:00"}]}},
+            "pump": {"enabled": False},
+        }
+        resp = self.client.post("/schedule/validate", json=payload)
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(resp.get_json()["valid"])
+
+    def test_validate_rejects_a_non_object(self):
+        self.assertEqual(self.client.post("/schedule/validate", json=[]).status_code, 400)
+
+    def test_installed_cron_is_listable(self):
+        body = self.client.get("/schedule/cron").get_json()
+        self.assertIn("count", body)
+        self.assertIsInstance(body["cron_lines"], list)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,6 +1,8 @@
 import datetime
 import unittest
+from unittest.mock import patch
 
+import config
 from app.sensors.schedule import schedule as sched
 
 
@@ -311,3 +313,101 @@ class ScheduleEndpointTestCase(unittest.TestCase):
         body = self.client.get("/schedule/cron").get_json()
         self.assertIn("count", body)
         self.assertIsInstance(body["cron_lines"], list)
+
+
+class OneTimePumpRunTestCase(unittest.TestCase):
+    """One-shot runs must be additive: adding or applying a recurring schedule
+    can never disturb them, and vice versa (issue #32 / the HA schedule trap)."""
+
+    def setUp(self):
+        self.now = datetime.datetime(2026, 8, 31, 9, 0)
+        self.crontab = []
+
+        def fake_read():
+            return list(self.crontab)
+
+        def fake_write(lines):
+            self.crontab = list(lines)
+
+        self.read_patch = patch.object(sched, "_read_crontab", fake_read)
+        self.write_patch = patch.object(sched, "_write_crontab", fake_write)
+        self.read_patch.start()
+        self.write_patch.start()
+        self.addCleanup(self.read_patch.stop)
+        self.addCleanup(self.write_patch.stop)
+
+    def test_next_occurrence_today_then_tomorrow(self):
+        self.assertEqual(
+            sched.next_occurrence("15:00", now=self.now), datetime.datetime(2026, 8, 31, 15, 0)
+        )
+        self.assertEqual(
+            sched.next_occurrence("08:00", now=self.now), datetime.datetime(2026, 9, 1, 8, 0)
+        )
+
+    def test_add_installs_one_dated_line(self):
+        run = sched.add_one_time_pump_run("15:00", 3, now=self.now)
+        self.assertEqual(run["at"], datetime.datetime(2026, 8, 31, 15, 0))
+        self.assertEqual(run["seconds"], 180)
+        self.assertEqual(len(self.crontab), 1)
+        line = self.crontab[0]
+        self.assertTrue(line.startswith("0 15 31 8 * /usr/local/bin/water 180 "))
+        self.assertIn(sched.ONCE_MARKER, line)
+
+    def test_duration_is_capped_by_the_hard_limit(self):
+        run = sched.add_one_time_pump_run("15:00", 99, now=self.now)
+        self.assertEqual(run["seconds"], config.MAX_PUMP_RUN_SECONDS)
+
+    def test_pending_runs_are_listed_and_expired_ones_are_not(self):
+        sched.add_one_time_pump_run("15:00", 3, now=self.now)
+        self.assertEqual(len(sched.one_time_pump_runs(now=self.now)), 1)
+        later = datetime.datetime(2026, 8, 31, 16, 0)
+        self.assertEqual(sched.one_time_pump_runs(now=later), [])
+
+    def test_prune_removes_only_expired_lines(self):
+        sched.add_one_time_pump_run("10:00", 3, now=self.now)  # today 10:00
+        sched.add_one_time_pump_run("15:00", 3, now=self.now)  # today 15:00
+        self.assertEqual(len(self.crontab), 2)
+        sched.prune_one_time_pump_runs(now=datetime.datetime(2026, 8, 31, 11, 0))
+        self.assertEqual(len(self.crontab), 1)
+        self.assertIn("15:00", self.crontab[0])
+
+    def test_prune_never_blanks_an_unreadable_crontab(self):
+        self.crontab = []
+        self.assertEqual(sched.prune_one_time_pump_runs(now=self.now), [])
+        self.assertEqual(self.crontab, [])
+
+    def test_applying_a_schedule_preserves_a_pending_one_off(self):
+        sched.add_one_time_pump_run("15:00", 3, now=self.now)
+        schedule = {
+            "lights": {"enabled": True, "days": {"mon": [{"onTime": "05:00", "offTime": "21:00"}]}},
+            "pump": {"enabled": True, "days": {"mon": [{"time": "09:00", "duration": 3}]}},
+        }
+        with patch.object(sched, "save_schedule"):
+            sched.apply_schedule(schedule)
+        once = [ln for ln in self.crontab if sched.ONCE_MARKER in ln]
+        self.assertEqual(len(once), 1, "applying a recurring schedule dropped the one-off")
+
+    def test_one_offs_are_excluded_from_installed_recurring_lines(self):
+        sched.add_one_time_pump_run("15:00", 3, now=self.now)
+        self.assertEqual(sched.installed_cron_lines(), [])
+
+    def test_clear_removes_pending_runs_only(self):
+        self.crontab = ["0 5 * * 1 /usr/local/bin/light 65 " + sched.CRON_MARKER]
+        sched.add_one_time_pump_run("15:00", 3, now=self.now)
+        self.assertEqual(sched.clear_one_time_pump_runs(), 1)
+        self.assertEqual(len(self.crontab), 1)
+        self.assertIn(sched.CRON_MARKER, self.crontab[0])
+        self.assertNotIn(sched.ONCE_MARKER, self.crontab[0])
+
+    def test_default_duration_takes_the_shortest_scheduled_run(self):
+        schedule = {
+            "pump": {
+                "enabled": True,
+                "days": {
+                    "mon": [{"time": "09:00", "duration": 3}, {"time": "12:00", "duration": 5}]
+                },
+            },
+            "lights": {"enabled": False},
+        }
+        self.assertEqual(sched.default_pump_duration(schedule), 3)
+        self.assertEqual(sched.default_pump_duration({"pump": {"enabled": False}}), 3)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -218,3 +218,23 @@ class ExpectedStateTestCase(unittest.TestCase):
     def test_pump_disabled_is_none(self):
         s = self._daily(runs=[{"time": "09:00", "duration": 3}], pump=False)
         self.assertIsNone(sched.expected_pump_run(s, now=self._at(9, 1)))
+
+    def test_next_pump_run_skips_runs_already_past(self):
+        runs = [{"time": h, "duration": 3} for h in ("01:00", "06:00", "09:00", "12:00")]
+        s = self._daily(runs=runs)
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9, 17)), self._at(12))
+        self.assertEqual(sched.next_pump_run(s, now=self._at(0, 30)), self._at(1))
+
+    def test_next_pump_run_rolls_into_tomorrow(self):
+        s = self._daily(runs=[{"time": "01:00", "duration": 3}])
+        expected = datetime.datetime(2026, 9, 1, 1, 0)  # the Tuesday after our Monday
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9)), expected)
+
+    def test_next_pump_run_none_when_disabled_or_empty(self):
+        self.assertIsNone(sched.next_pump_run(self._daily(runs=[], pump=False), now=self._at(9)))
+        self.assertIsNone(sched.next_pump_run(self._daily(runs=[]), now=self._at(9)))
+
+    def test_next_pump_run_uses_vacation_profile(self):
+        s = self._daily(runs=[{"time": "01:00", "duration": 3}])
+        s["vacation"] = {"enabled": True, "until": None}
+        self.assertEqual(sched.next_pump_run(s, now=self._at(9)), self._at(12))


### PR DESCRIPTION
**Supersedes #100, #101, #102 and #103**, which are closed in favour of this. Those were a nested stack — each contained its predecessors' commits, so this branch already *is* all five. Reviewing four extra PRs would have meant reading the same diff four times and working out a merge order.

Five commits, all found and verified on a live Gardyn Home (Pi Zero 2), presented in dependency order.

### 1. Driver construction was resetting the pins
`PWMLED(pin)` defaults to `initial_value=0`, so merely *constructing* `Light` or `Pump` writes zero to its pin. `app/__init__.py` imports every sensor blueprint at module level and each `routes.py` instantiates its driver at import — so **every start of the REST API switched the lights and pump off.**

```
light at 65%                        ->  pigs gdc 18 = 6500
sudo systemctl restart garden-api   ->  pigs gdc 18 = 0
```

Nothing errors and nothing is logged, so the only symptom is hardware silently disagreeing with the schedule — and power-cycling is a reasonable thing to try in response (see #3). `hardware.current_duty_fraction()` reads the live duty from pigpiod and both drivers pass it as `initial_value`. `initial_value=None` is **not** usable: gpiozero range-checks it and raises `TypeError`.

### 2. Nothing outside the MQTT service reached its published state
cron drives the actuators through the `light`/`water` CLIs; the REST API and physical button drive them directly. The service only published what it had itself commanded, so **Home Assistant showed the light OFF while it was on at 65%**, and OFF through an entire scheduled pump run. `restore_actuator_state()` also read a file that the cron path never updated, so after a power cut mid-photoperiod the tower stayed dark until the next scheduled on-time.

`reconcile_actuator_state()` polls both duty cycles every `ACTUATOR_POLL_SECONDS` (default 15) and republishes on change — gpiozero reads PWM duty back through pigpiod, verified: an external `light 30` was observed in-process as `30.0`, matching `pigs gdc`. `apply_scheduled_state()` replays the schedule's current expectation on connect. Pump runs are deliberately **not** auto-resumed: this runs on every connect, and a crash-looping service would re-trigger watering, whereas a missed run self-heals at the next one.

### 3. The next pump run was invisible
The writable *Pump Run Time* entity can only express one run per day, so on a multi-cycle schedule it sits frozen on the first. Adds a read-only `timestamp` sensor HA renders as a relative time.

### 4. Schedule derived state and dry runs
`GET /schedule/state` and `/schedule/next` expose what the schedule *means* now (previously MQTT-only). `POST /schedule/validate` compiles without applying — `POST /schedule` rewrites the live crontab as a side effect, so a malformed payload was discovered by applying it — and `GET /schedule/cron` reports what is actually installed.

### 5. One-time pump runs, and non-destructive HA edits
Both HA pump controls routed through `_set_everyday_pump()`, which wrote the first run over all seven days — touching **either** collapsed a multi-run schedule to one, cutting a seven-run tower from 21 min/day of watering to 3, silently. Both setters are now surgical, and a genuine one-shot mechanism replaces the misuse. `ONCE_MARKER` contains `CRON_MARKER` as a substring, so `apply_schedule()` excludes it explicitly — without that, applying any schedule would cancel a pending one-off (there is a test for exactly this).

Verified live: publishing `duration/set=4` left all seven runs and their times intact at the new duration.

### Overlaps you should know about
- **`mqtt.py` overlaps substantially with #95.** Both rewrite large parts of it (water/discovery/`on_message`). Whichever merges second will need a rebase — unavoidable, the work genuinely overlaps. #101 was deliberately made *not* to depend on #95's helpers, so either order works.
- Does **not** touch `app/web/index.html`, so it is independent of #105 and #98.

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **165 tests, OK**; `ruff check .` and `black --check .` clean.

---

### Related issues
Addresses **#3** (power loss recovery — both mechanisms behind "has to be cycled a few times"). Contributes to **#32** (schedule API endpoints) and **#63** (dashboard cards).
