### PR TITLE
fix(web): API-key prompt, actuator state, camera auth, timelapse, units and tower layout

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -70,6 +70,11 @@ IMAGE_INTERVAL_SECONDS=3600
 # TIMELAPSE_DIR=
 TIMELAPSE_MAX_FRAMES=720
 TIMELAPSE_FPS=12
+# Frames below which the UI warns there is little history yet (168 = 7 days hourly).
+# A build still works at any count; short archives are just slowed down to run for
+# roughly TIMELAPSE_TARGET_SECONDS instead of flashing past at the full frame rate.
+TIMELAPSE_MIN_FRAMES=168
+TIMELAPSE_TARGET_SECONDS=10
 
 # ── REST API auth (optional) ──
 # When set, non-localhost requests must send X-API-Key: <key>.

--- a/app/sensors/camera/camera.py
+++ b/app/sensors/camera/camera.py
@@ -76,18 +76,58 @@ def archive_frame(src_path, cam):
         logger.error("Timelapse archive failed for %s: %s", cam, exc)
 
 
+def _frame_stamp(path):
+    """Parse the capture time back out of an archived frame's filename."""
+    try:
+        name = os.path.basename(path).split(".")[0]
+        return datetime.datetime.strptime(name, "%Y%m%d-%H%M%S").isoformat()
+    except ValueError:
+        return None
+
+
+def framerate_for(count):
+    """Frame rate to assemble ``count`` frames at.
+
+    A week of hourly frames at the full rate is only a few seconds long, so slow
+    short archives down toward TIMELAPSE_TARGET_SECONDS rather than letting them
+    flash past. Never below 1fps, never above TIMELAPSE_FPS.
+    """
+    target = count / float(max(1, config.TIMELAPSE_TARGET_SECONDS))
+    return max(1, min(config.TIMELAPSE_FPS, int(round(target))))
+
+
+def clip_seconds(count):
+    """How long the assembled clip would run, at the rate framerate_for picks."""
+    if not count:
+        return 0.0
+    return round(count / float(framerate_for(count)), 1)
+
+
+def frame_stats(cam):
+    """Archived frame count plus first/last capture times, so the UI can say how
+    much history exists before a build is worth doing."""
+    frames = sorted(glob.glob(os.path.join(_frames_dir(cam), "*.jpg")))
+    return {
+        "frames": len(frames),
+        "first": _frame_stamp(frames[0]) if frames else None,
+        "last": _frame_stamp(frames[-1]) if frames else None,
+        "seconds": clip_seconds(len(frames)),
+    }
+
+
 def generate_timelapse(cam):
     """Assemble the archived frames for ``cam`` into an mp4. Raises
     FileNotFoundError if no frames have been archived yet."""
     folder = _frames_dir(cam)
-    if not glob.glob(os.path.join(folder, "*.jpg")):
+    frames = glob.glob(os.path.join(folder, "*.jpg"))
+    if not frames:
         raise FileNotFoundError("no frames archived yet")
     out = timelapse_path(cam)
     cmd = [
         "ffmpeg",
         "-y",
         "-framerate",
-        str(config.TIMELAPSE_FPS),
+        str(framerate_for(len(frames))),
         "-pattern_type",
         "glob",
         "-i",

--- a/app/sensors/camera/routes.py
+++ b/app/sensors/camera/routes.py
@@ -43,6 +43,20 @@ def get_timelapse(cam):
     return send_file(path, mimetype="video/mp4")
 
 
+@camera_blueprint.route("/timelapse/<cam>/status", methods=["GET"])
+def timelapse_status(cam):
+    """How much history is archived, so the UI can explain an empty player
+    instead of showing a blank video box."""
+    if cam not in camera.CAMERAS:
+        return jsonify(error="unknown camera"), 400
+    stats = camera.frame_stats(cam)
+    stats["min_frames"] = config.TIMELAPSE_MIN_FRAMES
+    stats["ready"] = stats["frames"] >= config.TIMELAPSE_MIN_FRAMES
+    stats["has_video"] = os.path.exists(camera.timelapse_path(cam))
+    stats["interval_seconds"] = config.IMAGE_INTERVAL_SECONDS
+    return jsonify(stats)
+
+
 @camera_blueprint.route("/timelapse/<cam>", methods=["POST"])
 def make_timelapse(cam):
     if cam not in camera.CAMERAS:

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -523,23 +523,39 @@
       } catch { $("meta").textContent = "offline"; conn(false); }
     }
 
+    // <img src> and <video src> are browser-issued requests that cannot carry the
+    // X-API-Key header, so they 401 whenever GARDEN_API_KEY is set. Fetch the bytes
+    // ourselves and hand the element a blob URL instead. Old URLs are revoked so the
+    // live-refresh loop does not leak one blob per frame.
+    async function loadMedia(id, path, ms) {
+      const el = $(id);
+      try {
+        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 20000);
+        if (r.status === 401) { needKey(); return false; }
+        if (!r.ok) return false;
+        const url = URL.createObjectURL(await r.blob());
+        if (el.dataset.url) URL.revokeObjectURL(el.dataset.url);
+        el.dataset.url = url; el.src = url;
+        if (el.tagName === "VIDEO") el.load();
+        return true;
+      } catch { return false; }
+    }
     function loadCams() {
-      $("cam-upper").src = "/camera/upper?t=" + Date.now();
-      $("cam-lower").src = "/camera/lower?t=" + Date.now();
+      loadMedia("cam-upper", "/camera/upper");
+      loadMedia("cam-lower", "/camera/lower");
     }
     function toggleCamAuto() {
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }
       else { clearInterval(camTimer); camTimer = null; }
     }
     function loadTimelapses() {
-      ["upper", "lower"].forEach(c => { $("tl-" + c).src = "/camera/timelapse/" + c + "?t=" + Date.now(); });
+      ["upper", "lower"].forEach(c => loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000));
     }
     async function makeTimelapse(cam) {
-      toast("Building " + cam + " timelapse… (can take a minute)");
+      toast("Building " + cam + " timelapse (can take a minute)");
       const r = await post("/camera/timelapse/" + cam);
-      if (r && !r.error) { const v = $("tl-" + cam); v.src = "/camera/timelapse/" + cam + "?t=" + Date.now(); v.load(); }
+      if (r && !r.error) await loadMedia("tl-" + cam, "/camera/timelapse/" + cam, 60000);
     }
-
     // A range input with no value attribute parks at its midpoint, so the UI used
     // to claim 50% while the hardware was off. Seed both the slider and its label
     // from the real value.

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -530,7 +530,7 @@
     async function loadMedia(id, path, ms) {
       const el = $(id);
       try {
-        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 20000);
+        const r = await fetchT(path + "?t=" + Date.now(), { headers: headers() }, ms || 30000);
         if (r.status === 401) { needKey(); return false; }
         if (!r.ok) return false;
         const url = URL.createObjectURL(await r.blob());
@@ -540,9 +540,17 @@
         return true;
       } catch { return false; }
     }
-    function loadCams() {
-      loadMedia("cam-upper", "/camera/upper");
-      loadMedia("cam-lower", "/camera/lower");
+    // Two USB captures at once contend on the Pi's bus (measured 17-20s each in
+    // parallel vs 2.5-3s sequentially), so take them one at a time and skip a tick
+    // rather than stacking passes when the interval is shorter than a full cycle.
+    let camBusy = false;
+    async function loadCams() {
+      if (camBusy) return;
+      camBusy = true;
+      try {
+        await loadMedia("cam-upper", "/camera/upper", 30000);
+        await loadMedia("cam-lower", "/camera/lower", 30000);
+      } finally { camBusy = false; }
     }
     function toggleCamAuto() {
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -298,9 +298,9 @@
       </div>
       <div class="row">
         <label>Brightness</label>
-        <input type="range" min="0" max="100" id="brightness" oninput="lbl('brightness')"
+        <input type="range" min="0" max="100" value="0" id="brightness" oninput="lbl('brightness')"
                onchange="post('/light/brightness', {value:+this.value}); setActive('light', +this.value>0)">
-        <span class="pct" id="brightness-val">50%</span>
+        <span class="pct" id="brightness-val">0%</span>
       </div>
     </div>
 
@@ -312,9 +312,9 @@
       </div>
       <div class="row">
         <label>Speed</label>
-        <input type="range" min="0" max="100" id="speed" oninput="lbl('speed')"
+        <input type="range" min="0" max="100" value="0" id="speed" oninput="lbl('speed')"
                onchange="post('/pump/speed', {value:+this.value}); setActive('pump', +this.value>0)">
-        <span class="pct" id="speed-val">100%</span>
+        <span class="pct" id="speed-val">0%</span>
       </div>
       <div class="row">
         <label>Run for</label>
@@ -540,9 +540,13 @@
       if (r && !r.error) { const v = $("tl-" + cam); v.src = "/camera/timelapse/" + cam + "?t=" + Date.now(); v.load(); }
     }
 
+    // A range input with no value attribute parks at its midpoint, so the UI used
+    // to claim 50% while the hardware was off. Seed both the slider and its label
+    // from the real value.
+    function setSlider(id, v) { $(id).value = Math.round(+v || 0); lbl(id); }
     async function syncToggles() {
-      try { setActive("light", ((await get("/light/brightness")).value || 0) > 0); } catch {}
-      try { setActive("pump", ((await get("/pump/speed")).value || 0) > 0); } catch {}
+      try { setSlider("brightness", (await get("/light/brightness")).value); setActive("light", +$("brightness").value > 0); } catch {}
+      try { setSlider("speed", (await get("/pump/speed")).value); setActive("pump", +$("speed").value > 0); } catch {}
     }
 
     async function loadGrow() {
@@ -799,7 +803,7 @@
       });
     }
     function toggleSettings() { $("settings").classList.toggle("open"); $("api-key").value = API_KEY; }
-    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); }
+    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); syncToggles(); }
 
     setupCollapsible();
     $("theme-btn").textContent = document.documentElement.dataset.theme === "dark" ? "🌙" : "☀️";

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -171,6 +171,7 @@
     /* Per-pod plant tracking */
     .pods { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
     @media (max-width:640px){ .pods { grid-template-columns:1fr 1fr; } }
+    .tlnote { font-size:.62rem; line-height:1.4; padding:4px 2px 0; }
     .pod { border:1px solid var(--line); background:var(--surface-2); border-radius:10px; padding:8px; }
     .pod .pn { font-size:.6rem; color:var(--faint); font-weight:700; letter-spacing:.05em; }
     .pod input { width:100%; margin:4px 0; font-size:.8rem; padding:4px 6px; border-radius:7px; }
@@ -341,8 +342,8 @@
         </span>
       </h2>
       <div class="cams">
-        <figure class="cam"><video id="tl-upper" controls preload="none" playsinline muted loop></video><figcaption>Upper timelapse</figcaption></figure>
-        <figure class="cam"><video id="tl-lower" controls preload="none" playsinline muted loop></video><figcaption>Lower timelapse</figcaption></figure>
+        <figure class="cam"><video id="tl-upper" controls preload="none" playsinline muted loop></video><figcaption>Upper timelapse</figcaption><div class="tlnote muted" id="tl-note-upper"></div></figure>
+        <figure class="cam"><video id="tl-lower" controls preload="none" playsinline muted loop></video><figcaption>Lower timelapse</figcaption><div class="tlnote muted" id="tl-note-lower"></div></figure>
       </div>
     </div>
 
@@ -564,13 +565,32 @@
       if ($("cam-auto").checked) { loadCams(); camTimer = setInterval(loadCams, camInterval); }
       else { clearInterval(camTimer); camTimer = null; }
     }
-    function loadTimelapses() {
-      ["upper", "lower"].forEach(c => loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000));
+    // A build works at any frame count, but an archive only hours old makes a
+    // clip barely a second long, so say how much history exists rather than
+    // leaving an empty player with no explanation.
+    async function loadTimelapses() {
+      for (const c of ["upper", "lower"]) {
+        const note = $("tl-note-" + c);
+        let st = null;
+        try { st = await get("/camera/timelapse/" + c + "/status"); } catch { }
+        if (!st) { note.textContent = ""; continue; }
+        if (st.has_video) await loadMedia("tl-" + c, "/camera/timelapse/" + c, 60000);
+        if (!st.frames) {
+          note.textContent = "No frames archived yet - one is captured automatically every "
+            + Math.round(st.interval_seconds / 60) + " min.";
+          continue;
+        }
+        const since = st.first ? new Date(st.first).toLocaleDateString() : "?";
+        const days = Math.max(1, Math.round(st.min_frames * st.interval_seconds / 86400));
+        note.textContent = st.frames + " frames since " + since + " - builds a ~" + st.seconds + "s clip"
+          + (st.ready ? "." : ". Recommended from " + st.min_frames + " frames (~" + days + " days).")
+          + (st.has_video ? "" : " No clip built yet.");
+      }
     }
     async function makeTimelapse(cam) {
       toast("Building " + cam + " timelapse (can take a minute)");
       const r = await post("/camera/timelapse/" + cam);
-      if (r && !r.error) await loadMedia("tl-" + cam, "/camera/timelapse/" + cam, 60000);
+      if (r && !r.error) await loadTimelapses();
     }
     // A range input with no value attribute parks at its midpoint, so the UI used
     // to claim 50% while the hardware was off. Seed both the slider and its label

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -232,6 +232,11 @@
 
     <div id="alerts"></div>
 
+    <div id="keyalert" class="alert-banner" style="display:none">
+      <span>API key required - this Pi sets <code>GARDEN_API_KEY</code>. Enter it in Settings to load data.</span>
+      <button class="btn" onclick="needKey()">Enter key</button>
+    </div>
+
     <div class="card" id="settings">
       <h2>Settings</h2>
       <div class="row">
@@ -421,6 +426,19 @@
     function toast(msg, err) { const t = $("toast"); t.textContent = msg; t.className = "show" + (err ? " err" : ""); setTimeout(() => t.className = "", 1600); }
     function conn(ok) { $("conn").className = "dot " + (ok ? "ok" : "bad"); }
 
+    // A 401 means the firmware has GARDEN_API_KEY set but this browser has no key
+    // (or a stale one). Surface it instead of leaving every tile blank - /health is
+    // exempt from auth, so the connection dot stays green and hides the real cause.
+    let keyPrompted = false;
+    function needKey() {
+      $("keyalert").style.display = "flex";
+      if (keyPrompted) return;
+      keyPrompted = true;
+      $("settings").classList.add("open");
+      $("api-key").value = API_KEY;
+      $("api-key").focus();
+    }
+
     // fetch with a timeout so a hung/unreachable Pi never freezes the UI.
     async function fetchT(path, opts, ms) {
       const ctrl = new AbortController();
@@ -430,6 +448,7 @@
     }
     async function get(path) {
       const r = await fetchT(path, { headers: headers() });
+      if (r.status === 401) { needKey(); throw new Error(401); }
       if (!r.ok) throw new Error(r.status);
       conn(true); return r.json();
     }
@@ -437,6 +456,7 @@
       try {
         const r = await fetchT(path, { method: "POST", headers: headers({ "Content-Type": "application/json" }), body: JSON.stringify(body || {}) });
         let d = {}; try { d = await r.json(); } catch {}
+        if (r.status === 401) needKey();
         conn(r.ok); toast(d.message || d.error || (r.ok ? "ok" : "error " + r.status), !r.ok); return d;
       } catch (e) { conn(false); toast(e.name === "AbortError" ? "request timed out" : "error: " + e.message, true); }
     }
@@ -779,7 +799,7 @@
       });
     }
     function toggleSettings() { $("settings").classList.toggle("open"); $("api-key").value = API_KEY; }
-    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); toast("key saved"); loadSystem(); refresh(); }
+    function saveKey() { API_KEY = $("api-key").value.trim(); localStorage.setItem("garden_key", API_KEY); $("keyalert").style.display = "none"; keyPrompted = false; toast("key saved"); loadSystem(); refresh(); }
 
     setupCollapsible();
     $("theme-btn").textContent = document.documentElement.dataset.theme === "dark" ? "🌙" : "☀️";

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -331,8 +331,8 @@
         </span>
       </h2>
       <div class="cams">
-        <figure class="cam"><img id="cam-upper" alt="upper camera"><figcaption>Upper</figcaption></figure>
-        <figure class="cam"><img id="cam-lower" alt="lower camera"><figcaption>Lower</figcaption></figure>
+        <figure class="cam"><img id="cam-upper" alt="upper camera"><figcaption id="cap-upper">Upper</figcaption></figure>
+        <figure class="cam"><img id="cam-lower" alt="lower camera"><figcaption id="cap-lower">Lower</figcaption></figure>
       </div>
       <h2 style="margin-top:18px">Timelapse
         <span style="display:flex; gap:8px">
@@ -543,13 +543,21 @@
     // Two USB captures at once contend on the Pi's bus (measured 17-20s each in
     // parallel vs 2.5-3s sequentially), so take them one at a time and skip a tick
     // rather than stacking passes when the interval is shorter than a full cycle.
+    // Consecutive frames of a stationary tower look identical, so without a
+    // timestamp there is no way to tell a refresh landed.
+    function stampCam(which, ok) {
+      const el = $("cap-" + which);
+      const name = which === "upper" ? "Upper" : "Lower";
+      el.textContent = name + " \u00b7 " + (ok ? new Date().toLocaleTimeString() : "capture failed");
+      el.style.color = ok ? "" : "var(--red)";
+    }
     let camBusy = false;
     async function loadCams() {
       if (camBusy) return;
       camBusy = true;
       try {
-        await loadMedia("cam-upper", "/camera/upper", 30000);
-        await loadMedia("cam-lower", "/camera/lower", 30000);
+        stampCam("upper", await loadMedia("cam-upper", "/camera/upper", 30000));
+        stampCam("lower", await loadMedia("cam-lower", "/camera/lower", 30000));
       } finally { camBusy = false; }
     }
     function toggleCamAuto() {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -493,6 +493,11 @@
     async function setPump(on) { await post(on ? "/pump/on" : "/pump/off"); setActive("pump", on); }
     async function runPump() { const s = +$("run-secs").value; await post("/pump/run", { seconds: s }); setActive("pump", true); }
 
+    // INA219 readings arrive at full float precision (0.24390243902439024 mA),
+    // which overflows the tile it is rendered into. Two decimals is already well
+    // past what the sensor resolves.
+    const fmtStat = v => (v == null || !isFinite(+v)) ? "\u2014" : (+v).toFixed(2);
+
     async function refresh() {
       const sensors = {
         "/temperature": ["s-temp", "temperature", true],
@@ -520,7 +525,12 @@
       } catch { $("s-water").textContent = "n/a"; $("s-water-gal").textContent = "n/a"; $("s-water-status").textContent = ""; }
       try {
         const p = await get("/pump/stats");
-        if (p.BusVoltage != null) { $("p-volt").textContent = p.BusVoltage; $("p-curr").textContent = p.BusCurrent; $("p-pow").textContent = p.Power; $("p-shunt").textContent = p.ShuntVoltage ?? "—"; }
+        if (p.BusVoltage != null) {
+          $("p-volt").textContent = fmtStat(p.BusVoltage);
+          $("p-curr").textContent = fmtStat(p.BusCurrent);
+          $("p-pow").textContent = fmtStat(p.Power);
+          $("p-shunt").textContent = fmtStat(p.ShuntVoltage);
+        }
         else { $("p-volt").textContent = $("p-curr").textContent = $("p-pow").textContent = $("p-shunt").textContent = "—"; }
       } catch { /* optional */ }
       $("updated").textContent = "updated " + new Date().toLocaleTimeString();

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -253,6 +253,11 @@
           <option value="dark">Dark</option>
           <option value="light">Light</option>
         </select>
+        <label>Units</label>
+        <select id="set-units" onchange="setUnits(this.value)">
+          <option value="c">Celsius</option>
+          <option value="f">Fahrenheit</option>
+        </select>
         <label>Live refresh</label>
         <select id="set-caminterval" onchange="setCamInterval(+this.value)">
           <option value="6000">6 s</option>
@@ -265,9 +270,9 @@
     <div class="card">
       <h2>Sensors <button class="ghost" onclick="refresh()">Refresh</button></h2>
       <div class="tiles">
-        <div class="tile"><div class="top">Air Temp</div><div class="val"><span id="s-temp">—</span><small>°C</small></div></div>
+        <div class="tile"><div class="top">Air Temp</div><div class="val"><span id="s-temp">—</span><small class="unit-temp">°C</small></div></div>
         <div class="tile"><div class="top">Humidity</div><div class="val"><span id="s-hum">—</span><small>%</small></div></div>
-        <div class="tile"><div class="top">PCB Temp</div><div class="val"><span id="s-pcb">—</span><small>°C</small></div></div>
+        <div class="tile"><div class="top">PCB Temp</div><div class="val"><span id="s-pcb">—</span><small class="unit-temp">°C</small></div></div>
         <div class="tile" id="s-water-card"><div class="top">Water <span class="statuschip" id="s-water-status"></span></div><div class="val"><span id="s-water-gal">—</span><small>gal</small></div><div class="muted" style="font-size:.68rem"><span id="s-water">—</span> cm</div><div class="bar"><i id="s-water-bar" style="width:0"></i></div></div>
       </div>
       <div class="tiles" style="margin-top:12px">
@@ -417,6 +422,7 @@
     let API_KEY = localStorage.getItem("garden_key") || "";
     let camTimer = null;
     let camInterval = +localStorage.getItem("camInterval") || 6000;
+    let units = localStorage.getItem("units") || "c";  // "c" or "f", remembered per browser
     let waterLowCm = null;  // tank-low threshold (cm) from /system; null = disabled
     const SCH_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
     const emptyDays = () => Object.fromEntries(SCH_DAYS.map(d => [d, []]));
@@ -468,6 +474,10 @@
     }
 
     function lbl(id) { $(id + "-val").textContent = $(id).value + "%"; }
+    // Sensors always report Celsius; the F conversion is presentation-only.
+    function fmtTemp(c) { const v = +c; if (!isFinite(v)) return "n/a"; return (units === "f" ? v * 9 / 5 + 32 : v).toFixed(1); }
+    function applyUnitLabels() { document.querySelectorAll(".unit-temp").forEach(e => { e.textContent = units === "f" ? "\u00b0F" : "\u00b0C"; }); }
+    function setUnits(u) { units = u; localStorage.setItem("units", u); applyUnitLabels(); refresh(); }
     function setActive(device, isOn) {
       $(device + "-on").classList.toggle("active", isOn);
       const off = $(device + "-off"); off.classList.toggle("active", !isOn); off.classList.toggle("danger", !isOn);
@@ -479,12 +489,13 @@
 
     async function refresh() {
       const sensors = {
-        "/temperature": ["s-temp", "temperature"],
-        "/humidity": ["s-hum", "humidity"],
-        "/pcb-temp": ["s-pcb", "pcb-temp"],
+        "/temperature": ["s-temp", "temperature", true],
+        "/humidity": ["s-hum", "humidity", false],
+        "/pcb-temp": ["s-pcb", "pcb-temp", true],
       };
-      for (const [path, [id, key]] of Object.entries(sensors)) {
-        try { $(id).textContent = (await get(path))[key]; } catch { $(id).textContent = "n/a"; }
+      for (const [path, [id, key, isTemp]] of Object.entries(sensors)) {
+        try { const v = (await get(path))[key]; $(id).textContent = isTemp ? fmtTemp(v) : v; }
+        catch { $(id).textContent = "n/a"; }
       }
       try {
         const w = await get("/distance"); const cm = w.distance;
@@ -861,6 +872,7 @@
     $("theme-btn").textContent = document.documentElement.dataset.theme === "dark" ? "🌙" : "☀️";
     $("set-theme").value = localStorage.getItem("theme") || "dark";
     $("set-caminterval").value = camInterval;
+    $("set-units").value = units; applyUnitLabels();
     loadSystem(); refresh(); loadGrow(); loadSchedule(); loadPods(); loadCams(); loadTimelapses(); syncToggles(); ping();
     setInterval(refresh, 30000);
     setInterval(ping, 10000);

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -172,6 +172,12 @@
     .pods { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
     @media (max-width:640px){ .pods { grid-template-columns:1fr 1fr; } }
     .tlnote { font-size:.62rem; line-height:1.4; padding:4px 2px 0; }
+    .towers { display:grid; grid-template-columns:repeat(3,1fr); gap:10px; align-items:start; }
+    @media (max-width:640px){ .towers { grid-template-columns:1fr; } }
+    .tower { display:flex; flex-direction:column; gap:6px; }
+    .thead { font-size:.62rem; font-weight:700; letter-spacing:.06em; color:var(--green); text-transform:uppercase;
+      text-align:center; padding:6px 4px; border:1px solid var(--line); border-radius:8px; background:var(--surface-2); }
+    .pod.empty { opacity:.5; border-style:dashed; }
     .pod { border:1px solid var(--line); background:var(--surface-2); border-radius:10px; padding:8px; }
     .pod .pn { font-size:.6rem; color:var(--faint); font-weight:700; letter-spacing:.05em; }
     .pod input { width:100%; margin:4px 0; font-size:.8rem; padding:4px 6px; border-radius:7px; }
@@ -369,7 +375,7 @@
     <div class="card">
       <h2>Plants <button class="ghost" onclick="savePods()">Save plants</button></h2>
       <p class="muted" style="margin:-4px 0 12px">Name each pod and tap the shapes to match the code printed on the physical pod.</p>
-      <div class="pods" id="pods"></div>
+      <div class="towers" id="pods"></div>
     </div>
 
     <div class="card">
@@ -737,38 +743,57 @@
       const p = plantCatalog.find(x => x.name === name);
       return p ? `${p.guide} · ${p.light_need} light · ~${p.days_to_harvest}d · ${p.difficulty}` : "";
     };
+    // Laid out as the physical tower: three columns (A left, B centre, C right),
+    // each site 1 (top) to 10 (bottom). Pod ids map 1-10=A, 11-20=B, 21-30=C.
+    const TOWERS = [["A", "left"], ["B", "centre"], ["C", "right"]];
+    const siteOf = id => TOWERS[Math.floor((id - 1) / 10)][0] + (((id - 1) % 10) + 1);
+    function podCell(i, opts) {
+      const p = pods[i];
+      if (!p.symbols) p.symbols = [];
+      const cell = document.createElement("div"); cell.className = "pod" + (p.name ? "" : " empty");
+      const pn = document.createElement("div"); pn.className = "pn";
+      pn.textContent = siteOf(p.id); pn.title = "pod " + p.id;
+      const isCustom = p.name && !plantCatalog.some(x => x.name === p.name);
+      const sel = document.createElement("select"); sel.innerHTML = opts;
+      sel.value = isCustom ? "__other__" : (p.name || "");
+      const custom = document.createElement("input"); custom.placeholder = "custom name"; custom.value = isCustom ? p.name : "";
+      custom.style.display = isCustom ? "" : "none";
+      const guide = document.createElement("div"); guide.className = "pguide muted"; guide.textContent = guideFor(p.name);
+      const mark = () => cell.classList.toggle("empty", !pods[i].name);
+      sel.onchange = () => {
+        if (sel.value === "__other__") { custom.style.display = ""; pods[i].name = custom.value; }
+        else { custom.style.display = "none"; custom.value = ""; pods[i].name = sel.value; }
+        guide.textContent = guideFor(pods[i].name); mark();
+      };
+      custom.onchange = () => { pods[i].name = custom.value; mark(); };
+      const shapes = document.createElement("div"); shapes.className = "shapes";
+      podShapes.forEach(sh => {
+        const b = document.createElement("button"); b.textContent = SHAPE_GLYPH[sh] || "?"; b.title = sh;
+        if (p.symbols.includes(sh)) b.classList.add("on");
+        b.onclick = () => {
+          const arr = pods[i].symbols;
+          const at = arr.indexOf(sh);
+          if (at >= 0) arr.splice(at, 1); else if (arr.length < 5) arr.push(sh);
+          b.classList.toggle("on", arr.includes(sh));
+        };
+        shapes.appendChild(b);
+      });
+      cell.append(pn, sel, custom, guide, shapes);
+      return cell;
+    }
     function renderPods() {
       const box = $("pods"); box.innerHTML = "";
       const opts = catalogOptionsHTML();
-      pods.forEach((p, i) => {
-        if (!p.symbols) p.symbols = [];
-        const cell = document.createElement("div"); cell.className = "pod";
-        const pn = document.createElement("div"); pn.className = "pn"; pn.textContent = "POD " + p.id;
-        const isCustom = p.name && !plantCatalog.some(x => x.name === p.name);
-        const sel = document.createElement("select"); sel.innerHTML = opts;
-        sel.value = isCustom ? "__other__" : (p.name || "");
-        const custom = document.createElement("input"); custom.placeholder = "custom name"; custom.value = isCustom ? p.name : "";
-        custom.style.display = isCustom ? "" : "none";
-        const guide = document.createElement("div"); guide.className = "pguide muted"; guide.textContent = guideFor(p.name);
-        sel.onchange = () => {
-          if (sel.value === "__other__") { custom.style.display = ""; pods[i].name = custom.value; }
-          else { custom.style.display = "none"; custom.value = ""; pods[i].name = sel.value; }
-          guide.textContent = guideFor(pods[i].name);
-        };
-        custom.onchange = () => { pods[i].name = custom.value; };
-        const shapes = document.createElement("div"); shapes.className = "shapes";
-        podShapes.forEach(s => {
-          const b = document.createElement("button"); b.textContent = SHAPE_GLYPH[s] || "?"; b.title = s;
-          if (p.symbols.includes(s)) b.classList.add("on");
-          b.onclick = () => {
-            const arr = pods[i].symbols;
-            const at = arr.indexOf(s);
-            if (at >= 0) arr.splice(at, 1); else if (arr.length < 5) arr.push(s);
-            b.classList.toggle("on", arr.includes(s));
-          };
-          shapes.appendChild(b);
-        });
-        cell.append(pn, sel, custom, guide, shapes); box.appendChild(cell);
+      TOWERS.forEach((t, ti) => {
+        const col = document.createElement("div"); col.className = "tower";
+        const head = document.createElement("div"); head.className = "thead";
+        head.textContent = "Tower " + t[0] + " \u00b7 " + t[1];
+        col.appendChild(head);
+        for (let k = 0; k < 10; k++) {
+          const i = ti * 10 + k;
+          if (pods[i]) col.appendChild(podCell(i, opts));
+        }
+        box.appendChild(col);
       });
     }
     function savePods() { post("/pods", pods); }

--- a/config.py
+++ b/config.py
@@ -146,6 +146,12 @@ TIMELAPSE_DIR = os.getenv(
 )
 TIMELAPSE_MAX_FRAMES = _get_int("TIMELAPSE_MAX_FRAMES", 720)
 TIMELAPSE_FPS = _get_int("TIMELAPSE_FPS", 12)
+# A build works with any number of frames, but a short archive played at the full
+# frame rate flashes past. Frame rate is scaled down to stretch small archives to
+# roughly TIMELAPSE_TARGET_SECONDS; MIN_FRAMES is only the point at which the UI
+# stops warning that there is not much history yet (168 = 7 days of hourly frames).
+TIMELAPSE_MIN_FRAMES = _get_int("TIMELAPSE_MIN_FRAMES", 168)
+TIMELAPSE_TARGET_SECONDS = _get_int("TIMELAPSE_TARGET_SECONDS", 10)
 
 # ---------------------------------------------------------------------------
 # REST API auth (optional). When GARDEN_API_KEY is set, non-localhost


### PR DESCRIPTION
Supersedes #96, #97 and #99, which are closed in favour of this. All three modified `app/web/index.html` — #97 and #99 touched **only** that file — so as separate PRs they conflicted pairwise and you would have resolved the same file three times. Folded into one review with the commits kept separate.

Nine commits, found and verified on a live Gardyn Home (Pi Zero 2, two USB cameras).

### Fixes — the UI silently failed with `GARDEN_API_KEY` set
`/health` is exempt from auth, so the connection dot stayed **green** while every sensor call returned 401 and each tile sat at a dash: the page looked connected and simply had no data, with the key field hidden behind the settings gear. `get()`/`post()` now trap 401, open settings and explain.

### Fixes — sliders reported values the hardware never had
Neither range input carried a `value` attribute, so the browser parked both at the **midpoint of min/max**, and the percent labels were hardcoded HTML (`50%`, `100%`). Observed live: UI showed 50% brightness / 100% pump speed while both were actually **0**. Since `onchange` only fires on a real change, a slider parked at a wrong value also made a corrective drag a no-op.

### Fixes — camera images could never load with auth on
`<img src>` and `<video src>` are browser-issued and **cannot carry the `X-API-Key` header**, so every still and timelapse 401'd. Now fetched in JS with the header and handed over as blob URLs, with old object URLs revoked so the live-refresh loop does not leak a blob per frame.

### Fixes — concurrent captures contend badly on a Pi Zero
| | Upper | Lower |
|---|---|---|
| Both at once | 16.8s | **20.0s** |
| Sequential | 3.1s | 2.5s |

The parallel pair blew the fetch timeout so neither image appeared. Now sequential behind a busy flag. Captions also carry a capture timestamp — a stationary tower looks identical frame to frame, so live mode was indistinguishable from a dead one.

### Fixes — pump stats overflowed their tiles
`/pump/stats` returns raw INA219 floats (`0.24390243902439024` mA) rendered verbatim into fixed-width tiles. Now two decimals, with the null handling that only the shunt reading previously had.

### Features
- **Timelapse usability** — `framerate_for()` stretches short archives toward `TIMELAPSE_TARGET_SECONDS` (8 frames → an 8s clip instead of 0.7s; `TIMELAPSE_MAX_FRAMES` is a cap, not a minimum), plus `GET /camera/timelapse/<cam>/status` and a notice under each player instead of a blank box.
- **Fahrenheit/Celsius toggle** — presentation-only, persisted per browser. Humidity untouched.
- **Tower-shaped plant grid** — three columns matching the unit (A left, B centre, C right), sites 1–10 top to bottom, labelled `A1`..`C10`. Empty sites dimmed and dashed so a deliberately unplanted socket reads differently from a failure.

### Overlaps you should know about
- **`app/web/index.html`** is also touched by #98 (two reminder-label lines) and by #104 (nothing). #98's change is in a distinct region and should merge cleanly either order.
- Nothing here touches `mqtt.py`, so this is independent of #95 and #104.

### Testing
`python -m unittest discover -t . -s tests -p 'test_*.py'` → **126 tests, OK**; `ruff check .` and `black --check .` clean; `node --check` on the extracted UI script passes.

---

### Related issues
Contributes to **#31** (camera API endpoints).
