### PR TITLE
docs(readme): fix an unclosed code fence and the off-Pi test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,8 @@ Open two terminals on the gardyn pi, in one run:
 
 In the second gardyn pi terminal, run:
 
-`mosquitto_pub -t "gardyn/water/level/get" -m ""-r  -u gardyn -P "somepassword"`
+`mosquitto_pub -t "gardyn/water/level/get" -m "" -r -u gardyn -P "somepassword"`
 
-```
 
 ### Testing
 
@@ -295,12 +294,24 @@ Test options:
 # REST endpoints
 ./bin/api-test.sh
 
-# unit test
-python -m unittest -v
+# unit tests — note the `-t .` so the tests PACKAGE loads
+python -m unittest discover -t . -s tests -p 'test_*.py'
 
-# individual tests
-python tests/test_distance.py
+# individual test module
+python -m unittest tests.test_distance
 ```
+
+> Use the `discover -t . -s tests` form. The hardware-stub bootstrap that lets
+> the suite run without a Pi lives in the `tests` package `__init__`, so a plain
+> `python -m unittest` imports `app` directly and fails off-Pi with an import
+> error on `gpiozero`/`board`.
+>
+> Run the suite **off** the Pi. `tests/_hwstub.py` injects fakes only when the
+> real GPIO libs are *absent* — on a Pi they are present, the stubs disengage,
+> and importing the app instantiates real GPIO drivers on a live unit.
+>
+> `bin/api-test.sh` spins the pump motor (`control_pump 30`). Don't run it
+> unless the pump is submerged.
 
 ### Controlling Individual Sensors
 


### PR DESCRIPTION
Two small, independent README bugs. No code changes — safe to merge on its own, and it does not depend on any of my other open PRs (#95, #98, #104, #105).

### 1. An unclosed code fence inverts half the page

There is a stray ` ``` ` between the MQTT sensor example and `### Testing`, with nothing opening it:

```
`mosquitto_pub -t "gardyn/water/level/get" -m ""-r  -u gardyn -P "somepassword"`

```            <-- opens a fence that never closes

### Testing
```

Fences toggle, so every fence after this one is inverted. On GitHub the entire second half of the README renders backwards — prose inside code blocks, shell commands as body text — through **Testing**, **Controlling Individual Sensors**, **REST API**, **Cron Job**, **Hardware Overview** and **Design Decisions**. The README has 41 fence markers today; an odd count is the tell.

Removing the stray fence restores the rest of the document. I also fixed `-m ""-r` to `-m "" -r` on the line above, which as written glues the empty topic value and the retain flag into a single argument.

### 2. The documented test command doesn't work off a Pi

```bash
python -m unittest -v
```

This fails on any machine without GPIO hardware:

```
ModuleNotFoundError: No module named 'gpiozero'
```

The hardware-stub bootstrap that makes the suite runnable without a Pi lives in the `tests` package `__init__`, so plain `python -m unittest` imports `app` directly and never loads it. The working invocation — and the one CI actually gates on — is:

```bash
python -m unittest discover -t . -s tests -p 'test_*.py'
```

So the documented command and the gating command disagreed, which is a rough first experience for a new contributor: the repo looks broken when it isn't.

Also adds two warnings that otherwise cost real time:

- **Don't run the suite on a Pi.** `tests/_hwstub.py` injects fakes only when the real GPIO libs are *absent*. On a tower they're present, the stubs disengage, and importing the app instantiates real GPIO drivers on a live unit full of plants.
- **`bin/api-test.sh` spins the pump motor** (`control_pump 30`) — don't run it unless the pump is submerged.

### Verification

Branched from `main`. 126 tests pass with the documented command; fence count is now even (40).
