### PR TITLE
feat(mqtt,config)!: deterministic HA entity ids and a per-unit topic namespace

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,6 +1,15 @@
 # ── Device identity (Home Assistant discovery) ──
-MQTT_IDENTIFIER=gardyn_03
-MQTT_BASETOPIC=gardyn
+# Unique per unit. It namespaces the MQTT topics, the Home Assistant device, and
+# every entity id (entities are <domain>.<MQTT_IDENTIFIER>_<suffix>), so running
+# a second Gardyn means changing only this line. Keep it slug-safe: lowercase
+# letters, digits and underscores.
+MQTT_IDENTIFIER=gardyn_01
+
+# MQTT_BASETOPIC defaults to MQTT_IDENTIFIER. Leave it unset unless you are
+# keeping an existing deployment on its old topics: setting the same value on
+# two units makes each receive the other's commands, because mqtt.py subscribes
+# to BASE_TOPIC + "/#".
+# MQTT_BASETOPIC=gardyn
 MQTT_DEVICE_MODEL="gardyn 3.0"
 MQTT_VERSION="1.0.0"
 

--- a/config.py
+++ b/config.py
@@ -37,9 +37,19 @@ KEEP_ALIVE_INTERVAL = _get_int("MQTT_KEEPALIVE_INTERVAL", 60)
 
 # Topic / device identity (used for Home Assistant discovery)
 VERSION = os.getenv("MQTT_VERSION", "1.0.0")
-IDENTIFIER = os.getenv("MQTT_IDENTIFIER", "gardyn-xx")
+# Keep this slug-safe (a-z, 0-9, underscore). It becomes both the MQTT topic
+# namespace and the entity-id prefix, and Home Assistant slugifies entity ids --
+# so "gardyn-xx" published to `gardyn-xx/...` while HA showed
+# `sensor.gardyn_xx_...`, quietly disagreeing with itself.
+IDENTIFIER = os.getenv("MQTT_IDENTIFIER", "gardyn_01")
 MODEL = os.getenv("MQTT_DEVICE_MODEL", "gardyn 3.0")
-BASE_TOPIC = os.getenv("MQTT_BASETOPIC", "gardyn")
+# Defaults to the identifier so each unit gets its own topic namespace. A shared
+# base topic is not cosmetic: mqtt.py subscribes to BASE_TOPIC + "/#", so two
+# units on the same one receive each other's commands and one tower's light
+# switch drives both. It also names the Home Assistant device, so sharing it
+# makes HA disambiguate the duplicate and mangle every entity id.
+# Override only to keep an existing deployment on its old topics.
+BASE_TOPIC = os.getenv("MQTT_BASETOPIC", IDENTIFIER)
 
 USERNAME = os.getenv("MQTT_USERNAME")
 PASSWORD = os.getenv("MQTT_PASSWORD")

--- a/mqtt.py
+++ b/mqtt.py
@@ -356,6 +356,16 @@ def send_discovery_messages(client):
 
     def pub(topic, payload, availability=True):
         body = {**payload, **avail} if availability else dict(payload)
+        # Pin the entity_id rather than letting Home Assistant derive one.
+        # Without object_id, HA builds the id from the *display name*, under
+        # rules that vary by release and by whether the device name collides
+        # with another device -- so two installs can end up with different ids
+        # for the same entity, and a dashboard cannot be written from the code
+        # alone. Deriving it from unique_id makes every id
+        # <domain>.<MQTT_IDENTIFIER>_<suffix>: identical in shape on every unit,
+        # and immune to someone renaming the entity in the HA UI.
+        if "unique_id" in body:
+            body.setdefault("object_id", body["unique_id"])
         client.publish(topic, json.dumps(body), retain=True)
 
     # Config for Light
@@ -500,7 +510,6 @@ def send_discovery_messages(client):
         "image_topic": BASE_TOPIC + "/image/upper_camera",
         "encoding": "",
         "content_type": "image/jpeg",
-        "object_id": IDENTIFIER + "_upper_camera",
         "device": device_info,
     }
     # Image entities aren't gated on availability (the MQTT image platform
@@ -515,7 +524,6 @@ def send_discovery_messages(client):
         "image_topic": BASE_TOPIC + "/image/lower_camera",
         "encoding": "",
         "content_type": "image/jpeg",
-        "object_id": IDENTIFIER + "_lower_camera",
         "device": device_info,
     }
     pub(TEMP_CONFIG_TOPIC, temp_config_payload, availability=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,22 @@ class ConfigParsingTestCase(unittest.TestCase):
         cfg = self._reload(WATER_LOW_CM="0")
         self.assertIsNone(cfg.WATER_LOW_CM)
 
+    def test_base_topic_defaults_to_the_identifier(self):
+        """Each unit must get its own topic namespace by default.
+
+        mqtt.py subscribes to BASE_TOPIC + "/#", so two units sharing a base
+        topic receive each other's commands -- one tower's light switch would
+        drive both. Defaulting to the identifier makes that require deliberate
+        misconfiguration rather than being the out-of-the-box behaviour.
+        """
+        cfg = self._reload(MQTT_IDENTIFIER="gardyn_02")
+        self.assertEqual(cfg.BASE_TOPIC, "gardyn_02")
+
+    def test_base_topic_override_still_wins(self):
+        """An existing deployment can stay on its old topics."""
+        cfg = self._reload(MQTT_IDENTIFIER="gardyn_02", MQTT_BASETOPIC="gardyn")
+        self.assertEqual(cfg.BASE_TOPIC, "gardyn")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -70,6 +70,37 @@ class DiscoveryTestCase(unittest.TestCase):
             self.assertIn("device", data, f"{topic} missing device block")
             self.assertIn("identifiers", data["device"])
 
+    def test_every_entity_pins_its_object_id(self):
+        """Entity ids must be deterministic, not derived from the display name.
+
+        Without object_id, Home Assistant builds the entity_id from the name
+        under rules that vary by release and by whether the device name
+        collides with another device, so the same entity can land on different
+        ids across installs. Pinning it to unique_id gives every unit the same
+        <MQTT_IDENTIFIER>_<suffix> shape.
+        """
+        client = FakeClient()
+        self.mqtt.send_discovery_messages(client)
+        for topic, payload in client.published:
+            data = json.loads(payload)
+            self.assertIn("object_id", data, f"{topic} does not pin an object_id")
+            self.assertEqual(
+                data["object_id"],
+                data["unique_id"],
+                f"{topic} object_id must track unique_id",
+            )
+            self.assertTrue(
+                data["object_id"].startswith(self.mqtt.IDENTIFIER + "_"),
+                f"{topic} object_id must be namespaced by MQTT_IDENTIFIER",
+            )
+
+    def test_object_ids_are_unique(self):
+        """Two entities sharing an object_id would collide into `_2` suffixes."""
+        client = FakeClient()
+        self.mqtt.send_discovery_messages(client)
+        ids = [json.loads(p)["object_id"] for _, p in client.published]
+        self.assertEqual(len(ids), len(set(ids)), "duplicate object_id in discovery")
+
     def test_button_event_types(self):
         client = FakeClient()
         self.mqtt.send_discovery_messages(client)


### PR DESCRIPTION
Branched from `main`, independent of my other open PRs (#95, #98, #104, #105) — 5 files, ~80 lines.

Two related problems that only surface after running a Gardyn for a while, or owning more than one. Both were found the hard way on a live tower this week.

### 1. Entity ids are not predictable from the code

Discovery sets `object_id` on the two cameras and nothing else, so HA derives the other 35 entity ids from the **display name** — under rules that vary by release and by whether the device name collides with another device. My tower ended up straddling two schemes, depending on when each entity was first discovered:

```
sensor.gardyn_temperature            # older entities — no identifier at all
sensor.gardyn_1_gardyn_water_depth   # added later — HA disambiguating a duplicate device name
```

Neither is derivable from this repo. The practical consequences:

- `docs/homeassistant/lovelace-example.yaml` **cannot be correct for anyone**. It currently ships ids like `sensor.gardyn_03_pcb_temp`, which are `unique_id` values, not entity ids — the real entity is `sensor.gardyn_pcb_temperature` or `sensor.gardyn_1_gardyn_pcb_temperature` depending on history. I could only write a working dashboard by reading the ids back out of a running Home Assistant.
- The identifier-less ids (`light.gardyn_light`) **collide outright** on a second unit, and HA resolves that by appending `_2`.

`pub()` now derives `object_id` from `unique_id` for every payload, so ids are uniformly `<domain>.<MQTT_IDENTIFIER>_<suffix>`. A dashboard becomes portable between units by find/replacing the identifier, and renaming an entity in the HA UI can no longer move it out from under one.

The suffix is the `unique_id`, so it isn't always the display-name slug (`Water Remaining` → `sensor.<id>_water_percent`). That's deliberate — the display name is cosmetic, the unique_id is the contract.

### 2. Two Gardyns cannot coexist

`BASE_TOPIC` defaulted to `"gardyn"` independently of `MQTT_IDENTIFIER`, and `mqtt.py` subscribes to `BASE_TOPIC + "/#"` — so two units on the defaults **receive each other's commands**. One tower's light switch drives both. `BASE_TOPIC` also names the HA device, so sharing it makes HA disambiguate the duplicate, which is probably where the `gardyn_1_gardyn_` prefixes above came from.

`BASE_TOPIC` now defaults to `IDENTIFIER`, so a second unit is one line:

```ini
MQTT_IDENTIFIER=gardyn_02
```

**`.env-dist` mattered as much as the default** — it hardcoded `MQTT_BASETOPIC=gardyn`, so anyone following the documented setup got the collision regardless of what `config.py` defaulted to. It now ships commented out.

### Deliberately not changed

The discovery topic keeps its hardcoded `gardyn` node_id segment (`homeassistant/sensor/gardyn/<object_id>/config`). HA identifies entities by `unique_id` and `object_id`, both already per-unit, so it's only a grouping label — and moving it would strand the old retained configs at their old topics, leaving HA showing every entity twice.

### Migration, and why this is inert for existing installs

`object_id` only applies when HA **first creates** a registry entry. HA matches on `unique_id`, which is unchanged, so existing entities keep their current ids indefinitely — this changes nothing for a running install until the owner opts in by deleting the MQTT device and letting it re-discover.

Worth knowing for anyone who does: deleting the device in HA also publishes empty retained payloads to the discovery topics, so the configs must be republished (restart `mqtt.service`) before the entities come back.

The `BREAKING CHANGE` footer covers the default move: a deployment that set **neither** variable will change topics on upgrade and its entities go unavailable until re-discovered. Setting `MQTT_BASETOPIC=gardyn` explicitly keeps it put; anything built from the old `.env-dist` set both and is unaffected. Happy to drop the `IDENTIFIER` default change (`gardyn-xx` → `gardyn_01`) if you'd rather keep that surface smaller — it's included because `gardyn-xx` is not slug-safe, so it published to `gardyn-xx/...` while HA showed `sensor.gardyn_xx_...`, disagreeing with itself.

### Tests

Four added — every payload pins `object_id`, `object_id`s are unique, `BASE_TOPIC` defaults to the identifier, and an explicit override still wins. 130 pass, `ruff` and `black` clean.
