### PR TITLE
fix(app): import blueprints lazily

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,23 +5,40 @@ from flask_cors import CORS
 
 import config
 
-from .sensors.camera.routes import camera_blueprint
-from .sensors.distance.routes import distance_blueprint
-from .sensors.grow.routes import grow_blueprint
-from .sensors.humidity.routes import humidity_blueprint
-from .sensors.light.routes import light_blueprint
-from .sensors.pcb_temp.routes import pcb_temp_blueprint
-from .sensors.pods.routes import pods_blueprint
-from .sensors.pump.routes import pump_blueprint
-from .sensors.schedule.routes import schedule_blueprint
-from .sensors.system.routes import system_blueprint
-from .sensors.temperature.routes import temperature_blueprint
-from .web.routes import web_blueprint
-
 logger = logging.getLogger(__name__)
+
+# Blueprint imports live inside create_app() on purpose -- see the note there.
 
 
 def create_app(config_name=None):
+    # Imported here, not at module scope. Every routes module instantiates its
+    # driver at import (`pump_control = PumpControl(...)`), so importing them
+    # from this file meant that *any* `import app.<anything>` constructed the
+    # full set of GPIO drivers -- Light, Pump, Distance, the lot.
+    #
+    # That is not theoretical. `bin/water.sh` runs `pump.py`, which imports
+    # `app.lib.hardware`, which imported this file: so every cron watering run
+    # was quietly building a second DistanceSensor alongside the MQTT service's
+    # own. Two processes triggering one ultrasonic sensor cross-talk and both
+    # read wrong, which is the failure docs/DEPLOYMENT.md warns about under
+    # "Two traps".
+    #
+    # Deferring them means `app.lib.*` -- the config helpers, water maths and
+    # state persistence -- can be imported by a CLI or a test without touching
+    # hardware at all.
+    from .sensors.camera.routes import camera_blueprint
+    from .sensors.distance.routes import distance_blueprint
+    from .sensors.grow.routes import grow_blueprint
+    from .sensors.humidity.routes import humidity_blueprint
+    from .sensors.light.routes import light_blueprint
+    from .sensors.pcb_temp.routes import pcb_temp_blueprint
+    from .sensors.pods.routes import pods_blueprint
+    from .sensors.pump.routes import pump_blueprint
+    from .sensors.schedule.routes import schedule_blueprint
+    from .sensors.system.routes import system_blueprint
+    from .sensors.temperature.routes import temperature_blueprint
+    from .web.routes import web_blueprint
+
     app = Flask(__name__)
 
     # CORS lives here (not run.py) so the test client and any WSGI host get

--- a/app/lib/state.py
+++ b/app/lib/state.py
@@ -20,11 +20,21 @@ DEFAULT_STATE = {
 
 
 def load_state():
+    """Return the persisted state, with DEFAULT_STATE filling any gaps.
+
+    Every key in the file is preserved, not only those in DEFAULT_STATE. The old
+    behaviour dropped anything else on load, so ``save_state(**changes)`` -- which
+    accepts any key -- would write a value that the next ``load_state`` silently
+    threw away. Nothing in tree relied on that yet, which is exactly why it was
+    worth fixing before something did.
+    """
     try:
         with open(config.STATE_FILE) as fh:
             data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError("state file is not a JSON object")
         merged = dict(DEFAULT_STATE)
-        merged.update({k: data[k] for k in DEFAULT_STATE if k in data})
+        merged.update(data)
         return merged
     except (FileNotFoundError, ValueError):
         return dict(DEFAULT_STATE)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -44,5 +44,39 @@ class ActuatorStateTestCase(unittest.TestCase):
         self.assertTrue(s["light_on"])
 
 
+class StateRoundTripTestCase(unittest.TestCase):
+    """Keys outside DEFAULT_STATE must survive a save/load round trip.
+
+    load_state() used to keep only the four actuator fields, so anything else a
+    caller persisted was written and then silently discarded on the next read.
+    save_state(**changes) accepts any key, which made it a write-only store for
+    everything else -- a trap for the next feature that needs to remember
+    something.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._orig = config.STATE_FILE
+        config.STATE_FILE = os.path.join(self.tmp, "state.json")
+        self.addCleanup(setattr, config, "STATE_FILE", self._orig)
+
+    def test_extra_keys_survive_a_round_trip(self):
+        state.save_state(some_future_setting="06:30", a_flag=True)
+        loaded = state.load_state()
+        self.assertEqual(loaded["some_future_setting"], "06:30")
+        self.assertTrue(loaded["a_flag"])
+
+    def test_defaults_still_fill_missing_keys(self):
+        state.save_state(some_future_setting="06:30")
+        loaded = state.load_state()
+        for key, value in state.DEFAULT_STATE.items():
+            self.assertEqual(loaded[key], value, f"{key} should fall back to its default")
+
+    def test_a_non_object_state_file_falls_back_to_defaults(self):
+        with open(config.STATE_FILE, "w") as fh:
+            fh.write("[1, 2, 3]")
+        self.assertEqual(state.load_state(), dict(state.DEFAULT_STATE))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #120.

`app/__init__.py` imports every routes module at module scope, and each instantiates its driver at import:

```python
distance_control = DistanceControl(pin_factory=get_pin_factory())
```

So `import app.<anything>` constructs the **full set** of GPIO drivers — Light, Pump, Distance — whether or not the importer wanted a Flask app.

### This happens in normal operation

`bin/water.sh` is what cron runs to water. It invokes `app/sensors/pump/pump.py`, which begins:

```python
from app.lib import hardware      # <-- imports the `app` package
```

That runs `app/__init__.py` and builds a **second `DistanceSensor`** on the same echo/trigger pins the long-running MQTT service is already polling. Every scheduled watering run does this, and `bin/light.sh` takes the same path. Two processes triggering one ultrasonic sensor cross-talk and both come back wrong.

I found this while building a dry-run guard for the cron path downstream: the guard reads a persisted verdict rather than the sensor *precisely because* of sensor contention — and then I discovered that merely importing a helper to do so would itself create another driver.

### The change

The blueprint imports move inside `create_app()`, their only consumer. Nothing else changes — `mqtt.py` already imports the three routes modules it actually wants by name. `app.lib.*` becomes importable without touching hardware, which also makes the suite safer to run on a Pi.

### Also included

`load_state()` kept only keys already present in `DEFAULT_STATE`:

```python
merged.update({k: data[k] for k in DEFAULT_STATE if k in data})
```

`save_state(**changes)` accepts any key, so it wrote values that the next `load_state` silently discarded — a write-only store for anything beyond the four actuator fields. Nothing in tree relies on it yet, which is exactly why it seemed worth fixing before something did. Three tests cover the round trip.

---

129 tests green (126 upstream + 3 new), ruff and black clean. Independent of #95 — no overlapping files.
