### PR TITLE
fix(setup): render systemd units outside the repo

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -7,6 +7,21 @@ LOG_FILE="/tmp/install_packages.log"
 PYTHON_ENV_LOG_FILE="/tmp/setup_python_env.log"
 VERBOSE=false
 
+# Generated systemd units are rendered here, never into the repo.
+#
+# They used to be written over services/etc/systemd/system/*.service, and
+# mqtt.service is tracked in git. Since the rendered unit carries this host's
+# $USER and $INSTALL_DIR, that left every deployed Pi with a permanently dirty
+# working tree -- which hid real drift, and, worse, meant any future commit
+# touching that file would make bin/autoupdate.sh's `git pull --ff-only` refuse.
+# It exits 0 on that path, so the tower would simply stop taking updates, with
+# one line in a log nobody reads as the only evidence.
+#
+# The tracked file stays as a reference copy of the unit's shape; nothing writes
+# to it any more.
+GENERATED_DIR=$(mktemp -d -t garden-units-XXXXXX)
+trap 'rm -rf "$GENERATED_DIR"' EXIT
+
 # Safety flags
 DRY_RUN=false
 ASSUME_YES=false
@@ -358,7 +373,7 @@ function enable_pigpiod_service {
 
 # Setup and start MQTT service
 function setup_mqtt_service {
-    local service_file="$INSTALL_DIR/services/etc/systemd/system/mqtt.service"
+    local service_file="$GENERATED_DIR/mqtt.service"
 
     cat > $service_file <<EOF
 [Unit]
@@ -391,7 +406,7 @@ EOF
 
 # Setup and start the REST API + web UI service (served by waitress on :5000).
 function setup_api_service {
-    local service_file="$INSTALL_DIR/services/etc/systemd/system/garden-api.service"
+    local service_file="$GENERATED_DIR/garden-api.service"
     mkdir -p "$(dirname "$service_file")"
 
     cat > $service_file <<EOF
@@ -420,7 +435,7 @@ EOF
 
 # Boot heartbeat: pulse the lights on startup so power-on is visibly confirmed.
 function setup_boot_indicator {
-    local service_file="$INSTALL_DIR/services/etc/systemd/system/garden-boot-indicator.service"
+    local service_file="$GENERATED_DIR/garden-boot-indicator.service"
     mkdir -p "$(dirname "$service_file")"
 
     cat > $service_file <<EOF
@@ -448,8 +463,8 @@ EOF
 # Nightly auto-update: a timer that fast-forwards the branch and restarts the
 # services only when something changed (bin/autoupdate.sh does the safe pull).
 function setup_autoupdate {
-    local svc="$INSTALL_DIR/services/etc/systemd/system/garden-autoupdate.service"
-    local tmr="$INSTALL_DIR/services/etc/systemd/system/garden-autoupdate.timer"
+    local svc="$GENERATED_DIR/garden-autoupdate.service"
+    local tmr="$GENERATED_DIR/garden-autoupdate.timer"
     mkdir -p "$(dirname "$svc")"
 
     chmod +x "$INSTALL_DIR/bin/autoupdate.sh"

--- a/services/etc/systemd/system/mqtt.service
+++ b/services/etc/systemd/system/mqtt.service
@@ -1,3 +1,19 @@
+# REFERENCE COPY -- editing this file changes nothing on a running tower.
+#
+# bin/setup.sh renders the real unit from a template inside the script, filling
+# in this host's $USER and install directory, and installs that to
+# /etc/systemd/system/mqtt.service. The User= and paths below are defaults and
+# will not match your Pi unless you happen to share them.
+#
+# To change the running unit: edit the heredoc in setup.sh's setup_mqtt_service
+# and re-run it, or edit /etc/systemd/system/mqtt.service directly followed by
+# `sudo systemctl daemon-reload`.
+#
+# setup.sh used to overwrite this file in place. Because it is tracked in git,
+# that left every deployed Pi with a dirty working tree and would eventually
+# have made bin/autoupdate.sh's `git pull --ff-only` refuse -- silently ending
+# automatic updates.
+
 [Unit]
 Description=MQTT Service
 Requires=pigpiod.service


### PR DESCRIPTION
Fixes #112.

`bin/setup.sh` writes each generated systemd unit over `services/etc/systemd/system/*.service`, and `mqtt.service` is **tracked in git**:

```bash
local service_file="$INSTALL_DIR/services/etc/systemd/system/mqtt.service"
cat > $service_file <<EOF
...
User=$USER
WorkingDirectory=$INSTALL_DIR
```

The rendered unit carries this host's `$USER` and install directory, so on any machine whose user or install path differs from the shipped defaults — which is most of them — running `setup.sh` leaves the working tree permanently modified.

### Why that is worse than cosmetic

`bin/autoupdate.sh` runs nightly and does:

```bash
if ! git pull --ff-only --quiet; then
    log "git pull --ff-only failed; skipping"
    exit 0
fi
```

Any future commit that touches `services/etc/systemd/system/mqtt.service` makes that pull refuse — local changes would be overwritten. The script exits 0 on that path, so the unit **silently stops taking updates**, with one line in a log nobody reads as the only evidence. A tower can sit months behind and still look healthy.

It also means `git status` is never clean on a deployed Pi, so genuine local drift is invisible against the permanent noise.

### The change

Units render into a `mktemp -d` directory, removed by an `EXIT` trap, and are copied to `/etc/systemd/system` from there. Nothing writes into the repo any more. This covers all five generated units — `mqtt`, `garden-api`, `garden-boot-indicator`, and the autoupdate service/timer. The latter four happen to be untracked today, so they only littered `git status` rather than breaking the pull, but they were the same pattern.

The tracked `mqtt.service` stays as a reference copy of the unit's shape and gains a header saying editing it does nothing — that seemed worth stating explicitly, since it is exactly what someone would try.

---

No behaviour change to the installed units themselves; the same content lands in `/etc/systemd/system`. `bash -n` clean.
